### PR TITLE
feat: support for the webhooks api

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import {
   addContactTools,
   addEmailTools,
   addTopicTools,
+  addWebhookTools,
 } from './tools/index.js';
 
 // Parse command line arguments
@@ -55,6 +56,7 @@ addBroadcastTools(server, resend, {
 addContactTools(server, resend);
 addEmailTools(server, resend, { senderEmailAddress, replierEmailAddresses });
 addTopicTools(server, resend);
+addWebhookTools(server, resend);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -3,3 +3,4 @@ export * from './broadcasts.js';
 export * from './contacts.js';
 export * from './emails.js';
 export * from './topics.js';
+export * from './webhooks.js';

--- a/tools/webhooks.ts
+++ b/tools/webhooks.ts
@@ -1,0 +1,210 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { z } from 'zod';
+
+const webhookEventSchema = z.enum([
+  'email.sent',
+  'email.scheduled',
+  'email.delivered',
+  'email.delivery_delayed',
+  'email.complained',
+  'email.bounced',
+  'email.opened',
+  'email.clicked',
+  'email.received',
+  'email.failed',
+  'email.suppressed',
+  'contact.created',
+  'contact.updated',
+  'contact.deleted',
+  'domain.created',
+  'domain.updated',
+  'domain.deleted',
+]);
+
+export function addWebhookTools(server: McpServer, resend: Resend) {
+  server.tool(
+    'create-webhook',
+    'Create a new webhook in Resend. A webhook allows you to receive notifications at a specified URL when certain events occur (e.g. email.sent, email.delivered, email.bounced).',
+    {
+      endpoint: z
+        .string()
+        .url()
+        .describe('The URL where webhook events will be sent'),
+      events: webhookEventSchema
+        .array()
+        .min(1)
+        .describe('Array of event types to subscribe to'),
+    },
+    async ({ endpoint, events }) => {
+      console.error(
+        `Debug - Creating webhook for endpoint: ${endpoint} with events: ${events.join(', ')}`,
+      );
+
+      const response = await resend.webhooks.create({ endpoint, events });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to create webhook: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const created = response.data;
+      return {
+        content: [
+          { type: 'text', text: 'Webhook created successfully.' },
+          {
+            type: 'text',
+            text: `ID: ${created.id}\nSigning Secret: ${created.signing_secret}`,
+          },
+          {
+            type: 'text',
+            text: 'IMPORTANT: Make sure to tell the user the signing secret — they will need it to verify webhook payloads and it cannot be retrieved again later.',
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'list-webhooks',
+    'List all webhooks from Resend. This tool is useful for getting webhook IDs and seeing which endpoints and events are configured.',
+    {},
+    async () => {
+      console.error('Debug - Listing webhooks');
+
+      const response = await resend.webhooks.list();
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list webhooks: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const webhooks = response.data.data;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${webhooks.length} webhook${webhooks.length === 1 ? '' : 's'}${webhooks.length === 0 ? '.' : ':'}`,
+          },
+          ...webhooks.map(({ id, endpoint, status, events, created_at }) => ({
+            type: 'text' as const,
+            text: `Endpoint: ${endpoint}\nStatus: ${status}\nEvents: ${events?.join(', ') ?? 'none'}\nID: ${id}\nCreated at: ${created_at}`,
+          })),
+          ...(webhooks.length === 0
+            ? []
+            : [
+                {
+                  type: 'text' as const,
+                  text: "Don't bother telling the user the IDs or creation dates unless they ask for them.",
+                },
+              ]),
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'get-webhook',
+    'Get a webhook by ID from Resend.',
+    {
+      webhookId: z.string().nonempty().describe('Webhook ID'),
+    },
+    async ({ webhookId }) => {
+      console.error(`Debug - Getting webhook with id: ${webhookId}`);
+
+      const response = await resend.webhooks.get(webhookId);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to get webhook: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const webhook = response.data;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Endpoint: ${webhook.endpoint}\nStatus: ${webhook.status}\nEvents: ${webhook.events?.join(', ') ?? 'none'}\nID: ${webhook.id}\nCreated at: ${webhook.created_at}\nSigning Secret: ${webhook.signing_secret}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'update-webhook',
+    'Update an existing webhook in Resend. You can change the endpoint URL, subscribed events, or enable/disable the webhook.',
+    {
+      webhookId: z.string().nonempty().describe('Webhook ID'),
+      endpoint: z
+        .string()
+        .url()
+        .optional()
+        .describe('New URL where webhook events will be sent'),
+      events: webhookEventSchema
+        .array()
+        .min(1)
+        .optional()
+        .describe('New array of event types to subscribe to'),
+      status: z
+        .enum(['enabled', 'disabled'])
+        .optional()
+        .describe('Webhook status'),
+    },
+    async ({ webhookId, endpoint, events, status }) => {
+      console.error(`Debug - Updating webhook with id: ${webhookId}`);
+
+      const response = await resend.webhooks.update(webhookId, {
+        endpoint,
+        events,
+        status,
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to update webhook: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: 'text', text: 'Webhook updated successfully.' },
+          { type: 'text', text: `ID: ${response.data.id}` },
+          {
+            type: 'text',
+            text: "Don't bother telling the user the ID unless they ask for it.",
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'remove-webhook',
+    'Remove a webhook by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this webhook. Reference the ENDPOINT of the webhook when double-checking, and warn the user that removing a webhook is irreversible. You may only use this tool if the user explicitly confirms they want to remove the webhook after you double-check.',
+    {
+      webhookId: z.string().nonempty().describe('Webhook ID'),
+    },
+    async ({ webhookId }) => {
+      console.error(`Debug - Removing webhook with id: ${webhookId}`);
+
+      const response = await resend.webhooks.remove(webhookId);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to remove webhook: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: 'text', text: 'Webhook removed successfully.' },
+          { type: 'text', text: `ID: ${response.data.id}` },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
  - Add webhook management tools (create, list, get, update, remove) via the  
  Resend Webhooks API
  - Support subscribing to 17 event types across email, contact, and domain   
  events