### PR TITLE
feat: add GET /health

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -45,8 +45,13 @@ function extractBearerToken(req: IncomingMessage): string | null {
 export async function runHttp(
   options: ServerOptions,
   port: number,
-): Promise<void> {
+): Promise<Server> {
   const app = createMcpExpressApp();
+
+  app.get('/health', (_req: IncomingMessage, res: ServerResponse) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+  });
 
   app.all(
     '/mcp',
@@ -111,7 +116,7 @@ export async function runHttp(
     const server = app.listen(port, () => {
       console.error(`Resend MCP server listening on http://127.0.0.1:${port}`);
       console.error('  Streamable HTTP: POST/GET/DELETE /mcp');
-      resolve();
+      resolve(server);
     });
     server.once('error', reject);
 

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -1,3 +1,4 @@
+import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runHttp } from '../../src/transports/http.js';
 
@@ -17,8 +18,21 @@ describe('runHttp', () => {
   });
 
   it('starts server and resolves when listening', async () => {
-    await expect(
-      runHttp({ replierEmailAddresses: [] }, 0),
-    ).resolves.toBeUndefined();
+    const server = await runHttp({ replierEmailAddresses: [] }, 0);
+    expect(server).toBeDefined();
+    server.close();
+  });
+
+  it('GET /health returns 200 with status ok', async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+
+    server.close();
   });
 });


### PR DESCRIPTION
- this enables remote deployments and is a pattern used across other mcp servers
