### PR TITLE
feat: add get-tiptap-json-content tool and restore compose guidance

### DIFF
--- a/src/lib/resend-api-client.ts
+++ b/src/lib/resend-api-client.ts
@@ -73,4 +73,15 @@ export class ResendApiClient {
       content: data.content,
     });
   }
+
+  async getEditorContent(
+    resourceType: 'broadcast' | 'template',
+    resourceId: string,
+  ): Promise<{ content: Record<string, unknown> }> {
+    const params = new URLSearchParams({
+      resource_type: resourceType,
+      resource_id: resourceId,
+    });
+    return this.apiRequest('GET', `/editor/content?${params.toString()}`);
+  }
 }

--- a/src/lib/resend-editor-client.ts
+++ b/src/lib/resend-editor-client.ts
@@ -56,7 +56,7 @@ export class ResendEditorClient {
     id: string,
     data: { content: Record<string, unknown> },
   ): Promise<{ id: string; object: string }> {
-    return this.apiRequest('POST', '/editor/compose', {
+    return this.apiRequest('POST', '/editor/content', {
       resource_type: 'broadcast',
       resource_id: id,
       content: data.content,
@@ -67,7 +67,7 @@ export class ResendEditorClient {
     id: string,
     data: { content: Record<string, unknown> },
   ): Promise<{ id: string; object: string }> {
-    return this.apiRequest('POST', '/editor/compose', {
+    return this.apiRequest('POST', '/editor/content', {
       resource_type: 'template',
       resource_id: id,
       content: data.content,

--- a/src/lib/resend-editor-client.ts
+++ b/src/lib/resend-editor-client.ts
@@ -1,6 +1,6 @@
 const DEFAULT_API_URL = 'https://api.resend.com';
 
-export class ResendApiClient {
+export class ResendEditorClient {
   private apiUrl: string;
   private apiKey: string;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import packageJson from '../package.json' with { type: 'json' };
 import { DashboardClient } from './lib/dashboard-client.js';
-import { ResendApiClient } from './lib/resend-api-client.js';
+import { ResendEditorClient } from './lib/resend-editor-client.js';
 import {
   addApiKeyTools,
   addBroadcastTools,
@@ -33,7 +33,7 @@ export function createMcpServer(
   });
 
   const dashboard = new DashboardClient();
-  const apiClient = new ResendApiClient(apiKey);
+  const apiClient = new ResendEditorClient(apiKey);
 
   const { withEditorSession } = addEditorTools(server, dashboard, apiClient);
   addApiKeyTools(server, resend);

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -31,7 +31,11 @@ export function addBroadcastTools(
 - Newsletter, announcement, or bulk message to one audience
 - Supports personalization: {{{FIRST_NAME}}}, {{{LAST_NAME}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}
 
-**Workflow:** list-audiences (if needed) → create-broadcast → connect-to-editor + compose-broadcast + disconnect-from-editor (if using TipTap content) → send-broadcast( id ).`,
+**Workflow:** list-segments (if needed) → create-broadcast → compose-broadcast (to set email content editable in the dashboard) → send-broadcast.
+
+**Content options after creating:**
+- **compose-broadcast** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the email in the editor.
+- **update-broadcast with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
       inputSchema: {
         name: z
           .string()
@@ -337,11 +341,18 @@ export function addBroadcastTools(
       title: 'Compose Broadcast',
       description: `**Purpose:** Set the TipTap JSON content of a broadcast, enabling it to be edited visually in the Resend dashboard editor.
 
-**Workflow:** connect-to-editor → compose-broadcast → disconnect-from-editor
+**This is the recommended way to set email content.** Content set via compose-broadcast can be visually edited by the user in the dashboard. Use this for newsletters and any broadcast where the user may want to refine the content.
+
+**Workflow:** get-tiptap-json-content (if broadcast already has content) → get-tiptap-schema → connect-to-editor → compose-broadcast → disconnect-from-editor
 
 **When to use:**
-- User wants to edit a broadcast in the Resend dashboard editor
-- After create-broadcast, to set rich editable content instead of static HTML`,
+- After create-broadcast, to set the email body
+- When the user wants to write, edit, or style email content
+- When the user wants to collaborate on the email in the dashboard editor
+
+**Important:** If the broadcast already has content, call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+
+**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the broadcast already has HTML content, ask the user before switching to compose mode.`,
       inputSchema: {
         id: z.string().nonempty().describe('Broadcast ID'),
         content: z
@@ -367,8 +378,9 @@ export function addBroadcastTools(
     'update-broadcast',
     {
       title: 'Update Broadcast',
-      description:
-        'Update broadcast metadata by ID (name, subject, from, html, text, audience, preview text). To edit TipTap content, use compose-broadcast instead.',
+      description: `Update broadcast metadata by ID (name, subject, from, html, text, audience, preview text). To edit TipTap content, use compose-broadcast instead.
+
+**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-broadcast. This switch is lossy — some content or formatting may be lost. Prefer compose-broadcast for content changes. If the broadcast was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
       inputSchema: {
         id: z.string().nonempty().describe('Broadcast ID'),
         name: z.string().optional().describe('Name for the broadcast'),

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -2,12 +2,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
-import type { ResendApiClient } from '../lib/resend-api-client.js';
+import type { ResendEditorClient } from '../lib/resend-editor-client.js';
 
 export function addBroadcastTools(
   server: McpServer,
   resend: Resend,
-  apiClient: ResendApiClient,
+  apiClient: ResendEditorClient,
   {
     senderEmailAddress,
     replierEmailAddresses,
@@ -352,14 +352,14 @@ export function addBroadcastTools(
 
 **This is the recommended way to set email content.** Content set via compose-broadcast can be visually edited by the user in the dashboard. Use this for newsletters and any broadcast where the user may want to refine the content.
 
-**Workflow:** get-tiptap-json-content (if broadcast already has content) → get-tiptap-schema → compose-broadcast
+**Workflow:** get-tiptap-json-content → get-tiptap-schema → compose-broadcast
 
 **When to use:**
 - After create-broadcast, to set the email body
 - When the user wants to write, edit, or style email content
 - When the user wants to collaborate on the email in the dashboard editor
 
-**Important:** If the broadcast already has content, call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
 
 **Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the broadcast already has HTML content, ask the user before switching to compose mode.`,
       inputSchema: {

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -82,6 +82,47 @@ export function addEditorTools(
   );
 
   server.registerTool(
+    'get-tiptap-json-content',
+    {
+      title: 'Get TipTap JSON Content',
+      description: `**Purpose:** Retrieve the existing TipTap JSON content of a broadcast or template. Returns the full TipTap document JSON currently stored for the resource.
+
+**When to use:**
+- **Always call this before compose-broadcast or compose-template** when the resource already has content, so you can build on the existing document instead of overwriting it
+- When the user asks to edit, tweak, or modify existing email content
+- To inspect the current TipTap structure of a resource
+
+**Returns:** The TipTap JSON content object for the resource. Use this as the base for modifications, then pass the updated JSON to compose-broadcast or compose-template.`,
+      inputSchema: {
+        resource_type: z
+          .enum(['broadcast', 'template'])
+          .describe('Type of resource to fetch content for'),
+        resource_id: z
+          .string()
+          .nonempty()
+          .describe(
+            'The broadcast ID (UUID) or template identifier (UUID or alias)',
+          ),
+      },
+    },
+    async ({ resource_type, resource_id }) => {
+      const result = await apiClient.getEditorContent(
+        resource_type,
+        resource_id,
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result.content, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     'connect-to-editor',
     {
       title: 'Connect to Editor',

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { DashboardClient } from '../lib/dashboard-client.js';
-import type { ResendApiClient } from '../lib/resend-api-client.js';
+import type { ResendEditorClient } from '../lib/resend-editor-client.js';
 
 interface EditorConnection {
   resource_type: 'broadcast' | 'template';
@@ -12,7 +12,7 @@ interface EditorConnection {
 export function addEditorTools(
   server: McpServer,
   dashboard: DashboardClient,
-  apiClient: ResendApiClient,
+  apiClient: ResendEditorClient,
 ) {
   let activeConnection: EditorConnection | null = null;
 
@@ -88,7 +88,7 @@ export function addEditorTools(
       description: `**Purpose:** Retrieve the existing TipTap JSON content of a broadcast or template. Returns the full TipTap document JSON currently stored for the resource.
 
 **When to use:**
-- **Always call this before compose-broadcast or compose-template** when the resource already has content, so you can build on the existing document instead of overwriting it
+- **Always call this before compose-broadcast or compose-template** to fetch the current document state — even if you expect it to be empty, the resource may have content set via the dashboard
 - When the user asks to edit, tweak, or modify existing email content
 - To inspect the current TipTap structure of a resource
 

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -6,7 +6,7 @@ import type {
 } from 'resend';
 import { z } from 'zod';
 import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
-import type { ResendApiClient } from '../lib/resend-api-client.js';
+import type { ResendEditorClient } from '../lib/resend-editor-client.js';
 
 const templateVariableSchema = z.object({
   key: z
@@ -29,7 +29,7 @@ const templateVariableSchema = z.object({
 export function addTemplateTools(
   server: McpServer,
   resend: Resend,
-  apiClient: ResendApiClient,
+  apiClient: ResendEditorClient,
   {
     withEditorSession,
   }: {
@@ -269,14 +269,14 @@ export function addTemplateTools(
 
 **This is the recommended way to set email content.** Content set via compose-template can be visually edited by the user in the dashboard.
 
-**Workflow:** get-tiptap-json-content (if template already has content) → get-tiptap-schema → compose-template
+**Workflow:** get-tiptap-json-content → get-tiptap-schema → compose-template
 
 **When to use:**
 - After create-template, to set the email body
 - When the user wants to write, edit, or style email content
 - When the user wants to collaborate on the email in the dashboard editor
 
-**Important:** If the template already has content, call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
 
 **Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the template already has HTML content, ask the user before switching to compose mode.`,
       inputSchema: {

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -35,8 +35,11 @@ export function addTemplateTools(
     'create-template',
     {
       title: 'Create Template',
-      description:
-        'Create a new email template in Resend. Templates are created in draft status. Use publish-template to make them available for sending. Variables use triple-brace syntax in HTML: {{{VAR_NAME}}}. To set TipTap content after creation, use connect-to-editor → compose-template → disconnect-from-editor.',
+      description: `Create a new email template in Resend. Templates are created in draft status. Use publish-template to make them available for sending. Variables use triple-brace syntax in HTML: {{{VAR_NAME}}}.
+
+**Content options after creating:**
+- **compose-template** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the template in the editor.
+- **update-template with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
       inputSchema: {
         name: z.string().nonempty().describe('The name of the template.'),
         html: z
@@ -256,11 +259,18 @@ export function addTemplateTools(
       title: 'Compose Template',
       description: `**Purpose:** Set the TipTap JSON content of a template, enabling it to be edited visually in the Resend dashboard editor.
 
-**Workflow:** connect-to-editor → compose-template → disconnect-from-editor
+**This is the recommended way to set email content.** Content set via compose-template can be visually edited by the user in the dashboard.
+
+**Workflow:** get-tiptap-json-content (if template already has content) → get-tiptap-schema → connect-to-editor → compose-template → disconnect-from-editor
 
 **When to use:**
-- User wants to edit a template in the Resend dashboard editor
-- After create-template, to set rich editable content instead of static HTML`,
+- After create-template, to set the email body
+- When the user wants to write, edit, or style email content
+- When the user wants to collaborate on the email in the dashboard editor
+
+**Important:** If the template already has content, call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+
+**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the template already has HTML content, ask the user before switching to compose mode.`,
       inputSchema: {
         id: z.string().nonempty().describe('The template ID or alias.'),
         content: z
@@ -286,8 +296,9 @@ export function addTemplateTools(
     'update-template',
     {
       title: 'Update Template',
-      description:
-        'Update template metadata by ID or alias (name, subject, from, html, variables, etc.). After updating a published template, use publish-template again to make the changes live. To edit TipTap content, use compose-template instead.',
+      description: `Update template metadata by ID or alias (name, subject, from, html, variables, etc.). After updating a published template, use publish-template again to make the changes live. To edit TipTap content, use compose-template instead.
+
+**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-template. This switch is lossy — some content or formatting may be lost. Prefer compose-template for content changes. If the template was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
       inputSchema: {
         id: z.string().nonempty().describe('The template ID or alias.'),
         name: z.string().optional().describe('New name for the template.'),


### PR DESCRIPTION
## Summary

- Add `get-tiptap-json-content` MCP tool that fetches existing TipTap JSON content via `GET /editor/content` before composing, preventing accidental content loss when editing existing documents
- Add `getEditorContent` method to `ResendApiClient` for the new endpoint
- Restore compose-as-recommended guidance removed in #107: content options in create tools, recommended labels on compose tools, lossy switching warnings on update tools
- Update compose tool workflows to reference `get-tiptap-json-content` as a prerequisite step

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes (44/44)
- [ ] `npx biome check` passes on changed files
- [ ] Manual: start MCP server, verify `get-tiptap-json-content` appears in tool list
- [ ] Manual: call `get-tiptap-json-content` with a known broadcast/template ID, confirm TipTap JSON is returned