### PR TITLE
fix: remove filePath attachment option to prevent arbitrary file read (CWE-22)

### DIFF
--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
@@ -73,10 +72,6 @@ export function addEmailTools(
                 .describe(
                   'Name of the file with extension (e.g., "report.pdf")',
                 ),
-              filePath: z
-                .string()
-                .optional()
-                .describe('Local file path to read and attach'),
               url: z
                 .string()
                 .optional()
@@ -103,7 +98,7 @@ export function addEmailTools(
           )
           .optional()
           .describe(
-            'Array of file attachments. Each needs filename plus one of: filePath, url, or content. Max 40MB total.',
+            'Array of file attachments. Each needs filename plus one of: url or content. Max 40MB total.',
           ),
         tags: z
           .array(
@@ -225,36 +220,29 @@ export function addEmailTools(
       }
 
       if (attachments && attachments.length > 0) {
-        emailRequest.attachments = await Promise.all(
-          attachments.map(async (att) => {
-            const result: {
-              filename?: string;
-              content?: Buffer;
-              path?: string;
-              contentType?: string;
-              contentId?: string;
-            } = {};
+        emailRequest.attachments = attachments.map((att) => {
+          const result: {
+            filename?: string;
+            content?: Buffer;
+            path?: string;
+            contentType?: string;
+            contentId?: string;
+          } = {};
 
-            if (att.filename) result.filename = att.filename;
-            if (att.contentType) result.contentType = att.contentType;
-            if (att.contentId) result.contentId = att.contentId;
+          if (att.filename) result.filename = att.filename;
+          if (att.contentType) result.contentType = att.contentType;
+          if (att.contentId) result.contentId = att.contentId;
 
-            // Priority: filePath > url > content
-            if (att.filePath) {
-              // Read local file
-              const fileBuffer = await fs.readFile(att.filePath);
-              result.content = fileBuffer;
-            } else if (att.url) {
-              // Let Resend fetch from URL
-              result.path = att.url;
-            } else if (att.content) {
-              // Direct Base64 content
-              result.content = Buffer.from(att.content, 'base64');
-            }
+          if (att.url) {
+            // Let Resend fetch from URL
+            result.path = att.url;
+          } else if (att.content) {
+            // Direct Base64 content
+            result.content = Buffer.from(att.content, 'base64');
+          }
 
-            return result;
-          }),
-        );
+          return result;
+        });
       }
 
       if (tags && tags.length > 0) {

--- a/tests/tools/emails-filepath.test.ts
+++ b/tests/tools/emails-filepath.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
+import { describe, expect, it } from 'vitest';
 
 /**
  * CWE-22: Arbitrary file read via send-email attachment filePath parameter.
@@ -63,10 +62,7 @@ describe('CWE-22: filePath attachment path traversal', () => {
       // Fallback: try to parse a payload with filePath and verify it's stripped or rejected
       // If we can't introspect the schema, inspect the source code directly
       const sourceCode = await fs.readFile(
-        path.join(
-          import.meta.dirname,
-          '../../src/tools/emails.ts',
-        ),
+        path.join(import.meta.dirname, '../../src/tools/emails.ts'),
         'utf8',
       );
       // The source should not contain fs.readFile for attachment processing
@@ -80,10 +76,7 @@ describe('CWE-22: filePath attachment path traversal', () => {
 
   it('should not call fs.readFile for attachment file paths', async () => {
     const sourceCode = await fs.readFile(
-      path.join(
-        import.meta.dirname,
-        '../../src/tools/emails.ts',
-      ),
+      path.join(import.meta.dirname, '../../src/tools/emails.ts'),
       'utf8',
     );
 
@@ -93,10 +86,7 @@ describe('CWE-22: filePath attachment path traversal', () => {
 
   it('should not import node:fs/promises if filePath is removed', async () => {
     const sourceCode = await fs.readFile(
-      path.join(
-        import.meta.dirname,
-        '../../src/tools/emails.ts',
-      ),
+      path.join(import.meta.dirname, '../../src/tools/emails.ts'),
       'utf8',
     );
 

--- a/tests/tools/emails-filepath.test.ts
+++ b/tests/tools/emails-filepath.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * CWE-22: Arbitrary file read via send-email attachment filePath parameter.
+ *
+ * The `send-email` tool accepts a `filePath` parameter in attachments.
+ * An attacker who can influence MCP tool calls (e.g., via prompt injection)
+ * can set filePath to any path like '/etc/passwd' or '~/.ssh/id_rsa'.
+ * The server reads the file with no path validation and sends its contents
+ * as an email attachment to an attacker-controlled recipient address.
+ *
+ * Fix: Remove the filePath option entirely. Only allow url or base64 content.
+ */
+
+// We test by checking the Zod schema no longer accepts filePath,
+// and that the handler code no longer calls fs.readFile for attachments.
+
+describe('CWE-22: filePath attachment path traversal', () => {
+  it('should not expose filePath in the send-email input schema', async () => {
+    // Dynamically import the module to get the addEmailTools function
+    const { addEmailTools } = await import('../../src/tools/emails.js');
+
+    // Capture the registered tool schema
+    let registeredSchema: Record<string, unknown> | null = null;
+
+    const mockServer = {
+      registerTool: (
+        name: string,
+        config: { inputSchema: Record<string, unknown> },
+        _handler: unknown,
+      ) => {
+        if (name === 'send-email') {
+          registeredSchema = config.inputSchema;
+        }
+      },
+    };
+
+    const mockResend = {} as any;
+
+    addEmailTools(mockServer as any, mockResend, {
+      senderEmailAddress: 'test@example.com',
+      replierEmailAddresses: ['reply@example.com'],
+    });
+
+    expect(registeredSchema).not.toBeNull();
+
+    // The attachments schema should not contain filePath
+    const attachmentsSchema = registeredSchema!.attachments as any;
+    expect(attachmentsSchema).toBeDefined();
+
+    // Parse it to see the shape - the inner object schema should not have filePath
+    const schemaShape =
+      attachmentsSchema?._def?.innerType?._def?.type?._def?.shape?.() ??
+      attachmentsSchema?._def?.type?._def?.shape?.() ??
+      null;
+
+    if (schemaShape) {
+      expect(schemaShape).not.toHaveProperty('filePath');
+    } else {
+      // Fallback: try to parse a payload with filePath and verify it's stripped or rejected
+      // If we can't introspect the schema, inspect the source code directly
+      const sourceCode = await fs.readFile(
+        path.join(
+          import.meta.dirname,
+          '../../src/tools/emails.ts',
+        ),
+        'utf8',
+      );
+      // The source should not contain fs.readFile for attachment processing
+      // Check that filePath is not used in the attachment processing logic
+      const attachmentProcessingMatch = sourceCode.match(
+        /if\s*\(\s*att\.filePath\s*\)/,
+      );
+      expect(attachmentProcessingMatch).toBeNull();
+    }
+  });
+
+  it('should not call fs.readFile for attachment file paths', async () => {
+    const sourceCode = await fs.readFile(
+      path.join(
+        import.meta.dirname,
+        '../../src/tools/emails.ts',
+      ),
+      'utf8',
+    );
+
+    // The source should not contain fs.readFile(att.filePath) pattern
+    expect(sourceCode).not.toMatch(/fs\.readFile\s*\(\s*att\.filePath\s*\)/);
+  });
+
+  it('should not import node:fs/promises if filePath is removed', async () => {
+    const sourceCode = await fs.readFile(
+      path.join(
+        import.meta.dirname,
+        '../../src/tools/emails.ts',
+      ),
+      'utf8',
+    );
+
+    // If filePath is removed, there's no reason to import fs
+    expect(sourceCode).not.toMatch(
+      /import\s+fs\s+from\s+['"]node:fs\/promises['"]/,
+    );
+  });
+
+  // Variant attack paths documented:
+  // 1. Symlink escape: attacker provides filePath pointing to a symlink
+  //    that resolves outside any sandbox → same issue, fs.readFile follows symlinks
+  // 2. Encoding variants: filePath with URL-encoded '..' like '%2e%2e' —
+  //    Node's fs.readFile interprets paths literally so '%2e%2e' isn't '..',
+  //    but the direct '..' traversal works without encoding tricks
+  // Both are eliminated by removing filePath entirely.
+});


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22: Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal")**
**Severity:** High

### Data Flow

1. The `send-email` MCP tool accepts an `attachments` array, where each attachment object includes an optional `filePath` string parameter (defined via Zod schema in `src/tools/emails.ts`).
2. The handler calls `fs.readFile(att.filePath)` with **zero validation** — no path sanitization, no allowlisting, no canonicalization.
3. The file contents are attached to an email and sent via the Resend API to a **caller-controlled recipient address**.

### Attack Vectors

- **HTTP mode:** Any network client with access to the MCP server port can craft a JSON-RPC `tools/call` request with arbitrary `filePath` values (e.g., `/etc/passwd`, `~/.ssh/id_rsa`, `/app/.env`).
- **Stdio mode:** An attacker can influence `filePath` via prompt injection in content processed by the LLM.

### Impact

An attacker can read **any file** accessible to the Node.js process and exfiltrate it via email:
- SSH private keys (`~/.ssh/id_rsa`)
- Environment files with secrets (`/app/.env`)
- System credentials (`/etc/shadow` if readable)
- Application source code and configuration

---

## Fix Description

**Remove the `filePath` attachment option entirely** rather than attempting to validate paths (which is error-prone and bypass-susceptible).

### Changes (`src/tools/emails.ts`)

1. **Removed** `import fs from 'node:fs/promises'` — no longer needed.
2. **Removed** the `filePath` field from the Zod attachment schema.
3. **Removed** the `if (att.filePath) { fs.readFile(att.filePath) }` code path.
4. **Updated** the description string to reflect that only `url` or `content` are supported.
5. **Simplified** `Promise.all(attachments.map(async ...))` to a synchronous `attachments.map(...)` since `fs.readFile` was the only async operation.

### Rationale

- The `url` parameter (Resend fetches from a URL server-side) and `content` parameter (base64-encoded data) provide the same legitimate functionality without local filesystem access.
- Removing the feature entirely is safer than validation, which can be bypassed via symlinks, encoding tricks, or OS-specific path handling.
- This is the **only** `fs.readFile` call in `src/` — no other code path reads local files.

---

## Test Results

A new test file `tests/tools/emails-filepath.test.ts` validates the fix with three checks:

| Test | Description | Status |
|------|-------------|--------|
| Schema check | `filePath` not present in registered `send-email` input schema | ✅ Pass |
| Handler check | Source does not contain `fs.readFile(att.filePath)` pattern | ✅ Pass |
| Import check | Source does not import `node:fs/promises` | ✅ Pass |

The tests also document variant attack paths (symlink escape, encoding variants) that are all eliminated by removing `filePath` entirely.

---

## Disprove Analysis

We systematically attempted to disprove this finding:

### Authentication check
No authentication protects the `send-email` tool handler. The HTTP transport's Bearer token is a passthrough for the Resend API key, not caller authentication. In stdio mode, the LLM controls tool invocation directly.

### Network check
`app.listen(port)` binds to all interfaces by default (not just localhost). No reverse proxy or VPN is documented.

### Deployment check
No Dockerfile, docker-compose, or k8s manifests exist. The server is designed to run as a directly accessible local process or HTTP server.

### Caller trace
`att.filePath` originates from the MCP tool input schema (`z.string().optional()`) — fully attacker-controlled with no intermediate sanitization.

### Validation check
`grep -rn 'sanitize\|validate\|escape\|clean\|whitelist\|allowlist' src/tools/emails.ts` — **no validation found**.

### Prior reports
No existing security issues or prior fixes found in the repository.

### Fix adequacy
The fix is **not cosmetic**. `filePath` is the sole code path that reads local files in the entire codebase. Removing it eliminates the unique local-filesystem-read-to-email-exfiltration attack surface. The remaining `url` and `content` methods don't read local files.

### Mitigations found
**None.** No path validation, no sandboxing, no allowlisting, no chroot, no tool-level authentication.

### Verdict: **CONFIRMED_VALID** (high confidence)

---

## Diff Summary

```
 src/tools/emails.ts                 |  60 ++++++++-----------
 tests/tools/emails-filepath.test.ts | 106 ++++++++++++++++++++++++++++++++++++
 2 files changed, 130 insertions(+), 36 deletions(-)
```

Only the vulnerable file and a new test file are modified. No unrelated changes.

---

## References

- [CWE-22: Path Traversal](https://cwe.mitre.org/data/definitions/22.html)
- [OWASP Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
- [CAPEC-126: Path Traversal](https://capec.mitre.org/data/definitions/126.html)