### PR TITLE
feat: extend URL parsing to all remaining resource tools

### DIFF
--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -1,4 +1,37 @@
-const SUPPORTED_RESOURCES = ['broadcasts', 'templates', 'automations'];
+const SIMPLE_RESOURCES = [
+  'broadcasts',
+  'templates',
+  'automations',
+  'domains',
+  'api-keys',
+  'webhooks',
+  'logs',
+  'emails',
+];
+
+const NESTED_RESOURCES: Record<string, string[]> = {
+  audience: ['contacts', 'segments', 'topics'],
+};
+
+type SimpleResource =
+  | 'broadcasts'
+  | 'templates'
+  | 'automations'
+  | 'domains'
+  | 'api-keys'
+  | 'webhooks'
+  | 'logs'
+  | 'emails';
+
+type NestedResource = 'audience/contacts' | 'audience/segments' | 'audience/topics';
+
+type SupportedResource = SimpleResource | NestedResource;
+
+function formatResourceHint(resource: SupportedResource): string {
+  return resource.includes('/')
+    ? `https://resend.com/${resource}/<id>`
+    : `https://resend.com/${resource}/<id>`;
+}
 
 /**
  * Extracts a resource ID from a Resend dashboard URL.
@@ -7,13 +40,21 @@ const SUPPORTED_RESOURCES = ['broadcasts', 'templates', 'automations'];
  *   https://resend.com/broadcasts/<id>
  *   https://resend.com/templates/<id>
  *   https://resend.com/automations/<id>
+ *   https://resend.com/domains/<id>
+ *   https://resend.com/api-keys/<id>
+ *   https://resend.com/webhooks/<id>
+ *   https://resend.com/logs/<id>
+ *   https://resend.com/emails/<id>
+ *   https://resend.com/audience/contacts/<id>
+ *   https://resend.com/audience/segments/<id>
+ *   https://resend.com/audience/topics/<id>
  *
  * If the input is not a URL, it is returned as-is (assumed to be a raw ID).
  * If the input is a URL but cannot be resolved to an ID, an error is thrown.
  */
 export function extractIdFromUrl(
   input: string,
-  expectedResource?: 'broadcasts' | 'templates' | 'automations',
+  expectedResource?: SupportedResource,
 ): string {
   const trimmed = input.trim();
 
@@ -37,33 +78,66 @@ export function extractIdFromUrl(
   // Only handle resend.com URLs
   if (url.hostname !== 'resend.com' && url.hostname !== 'www.resend.com') {
     throw new Error(
-      `Unrecognized URL host "${url.hostname}". Expected a resend.com URL (e.g. https://resend.com/${expectedResource ?? 'broadcasts'}/<id>) or a raw resource ID.`,
+      `Unrecognized URL host "${url.hostname}". Expected a resend.com URL (e.g. ${formatResourceHint(expectedResource ?? 'broadcasts')}) or a raw resource ID.`,
     );
   }
 
-  // pathname is like /broadcasts/<id> or /templates/<id>
   const segments = url.pathname.split('/').filter(Boolean);
 
   if (segments.length < 2) {
-    const hint = segments[0] ?? expectedResource ?? 'broadcasts';
+    const hint = expectedResource ?? segments[0] ?? 'broadcasts';
     throw new Error(
-      `The URL "${trimmed}" is missing a resource ID. Expected a URL like https://resend.com/${hint}/<id>.`,
+      `The URL "${trimmed}" is missing a resource ID. Expected a URL like ${formatResourceHint(hint as SupportedResource)}.`,
     );
   }
 
+  // Try nested resource match first (e.g. /audience/contacts/<id>)
+  if (segments.length >= 3) {
+    const parent = segments[0];
+    const child = segments[1];
+    const nestedId = segments[2];
+    const nestedChildren = NESTED_RESOURCES[parent];
+
+    if (nestedChildren?.includes(child)) {
+      const nestedResource = `${parent}/${child}` as NestedResource;
+
+      if (expectedResource && nestedResource !== expectedResource) {
+        throw new Error(
+          `Expected a ${expectedResource} URL, but got a ${nestedResource} URL. Please provide a ${expectedResource} ID or URL (e.g. ${formatResourceHint(expectedResource)}).`,
+        );
+      }
+
+      return nestedId;
+    }
+  }
+
+  // Simple resource match (e.g. /broadcasts/<id>)
   const [resource, id] = segments;
+
+  if (expectedResource && expectedResource.includes('/')) {
+    // Expected a nested resource but got a simple path
+    throw new Error(
+      `Expected a ${expectedResource} URL, but got a ${resource} URL. Please provide a ${expectedResource} ID or URL (e.g. ${formatResourceHint(expectedResource)}).`,
+    );
+  }
 
   if (expectedResource && resource !== expectedResource) {
     throw new Error(
-      `Expected a ${expectedResource} URL, but got a ${resource} URL. Please provide a ${expectedResource} ID or URL (e.g. https://resend.com/${expectedResource}/<id>).`,
+      `Expected a ${expectedResource} URL, but got a ${resource} URL. Please provide a ${expectedResource} ID or URL (e.g. ${formatResourceHint(expectedResource)}).`,
     );
   }
 
-  if (SUPPORTED_RESOURCES.includes(resource)) {
+  if (SIMPLE_RESOURCES.includes(resource)) {
     return id;
   }
 
+  const allSupported = [
+    ...SIMPLE_RESOURCES,
+    ...Object.entries(NESTED_RESOURCES).flatMap(([parent, children]) =>
+      children.map((c) => `${parent}/${c}`),
+    ),
+  ];
   throw new Error(
-    `Unsupported resource type "${resource}" in URL. Only broadcasts, templates, and automations URLs are supported.`,
+    `Unsupported resource type "${resource}" in URL. Supported URL types: ${allSupported.join(', ')}.`,
   );
 }

--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addApiKeyTools(server: McpServer, resend: Resend) {
   server.registerTool(
@@ -146,12 +147,18 @@ export function addApiKeyTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove API Key',
       description:
-        'Remove an API key by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this API key. Reference the NAME of the API key when double-checking, and warn the user that removing an API key is irreversible and any services using it will lose access. You may only use this tool if the user explicitly confirms they want to remove the API key after you double-check.',
+        'Remove an API key by ID or dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this API key. Reference the NAME of the API key when double-checking, and warn the user that removing an API key is irreversible and any services using it will lose access. You may only use this tool if the user explicitly confirms they want to remove the API key after you double-check.',
       inputSchema: {
-        id: z.string().nonempty().describe('API key ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'API key ID or Resend dashboard URL (e.g. https://resend.com/api-keys/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'api-keys');
       const response = await resend.apiKeys.remove(id);
 
       if (response.error) {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -6,6 +6,7 @@ import type {
   UpdateContactResponse,
 } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addContactTools(server: McpServer, resend: Resend) {
   server.registerTool(
@@ -198,15 +199,22 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'get-contact',
     {
       title: 'Get Contact',
-      description: 'Get a contact by ID or email from Resend.',
+      description:
+        'Get a contact by ID, dashboard URL, or email from Resend.',
       inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
       },
     },
-    async ({ id, email }) => {
+    async ({ id: rawId, email }) => {
       let response: GetContactResponse;
-      if (id) {
+      if (rawId) {
+        const id = extractIdFromUrl(rawId, 'audience/contacts');
         response = await resend.contacts.get({ id });
       } else if (email) {
         response = await resend.contacts.get({ email });
@@ -253,9 +261,15 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'update-contact',
     {
       title: 'Update Contact',
-      description: 'Update a contact in Resend (by ID or email).',
+      description:
+        'Update a contact in Resend (by ID, dashboard URL, or email).',
       inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         firstName: z
           .string()
@@ -283,7 +297,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
           ),
       },
     },
-    async ({ id, email, firstName, lastName, unsubscribed, properties }) => {
+    async ({ id: rawId, email, firstName, lastName, unsubscribed, properties }) => {
       const commonOptions = {
         firstName,
         lastName,
@@ -292,7 +306,8 @@ export function addContactTools(server: McpServer, resend: Resend) {
       };
 
       let response: UpdateContactResponse;
-      if (id) {
+      if (rawId) {
+        const id = extractIdFromUrl(rawId, 'audience/contacts');
         response = await resend.contacts.update({ id, ...commonOptions });
       } else if (email) {
         response = await resend.contacts.update({ email, ...commonOptions });
@@ -323,15 +338,21 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Contact',
       description:
-        "Remove a contact from Resend (by ID or email). Before using this tool, you MUST double-check with the user that they want to remove this contact. Reference the contact's name (if present) and email address when double-checking, and warn the user that removing a contact is irreversible. You may only use this tool if the user explicitly confirms they want to remove the contact after you double-check.",
+        "Remove a contact from Resend (by ID, dashboard URL, or email). Before using this tool, you MUST double-check with the user that they want to remove this contact. Reference the contact's name (if present) and email address when double-checking, and warn the user that removing a contact is irreversible. You may only use this tool if the user explicitly confirms they want to remove the contact after you double-check.",
       inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
       },
     },
-    async ({ id, email }) => {
+    async ({ id: rawId, email }) => {
       let response: RemoveContactsResponse;
-      if (id) {
+      if (rawId) {
+        const id = extractIdFromUrl(rawId, 'audience/contacts');
         response = await resend.contacts.remove({ id });
       } else if (email) {
         response = await resend.contacts.remove({ email });
@@ -361,19 +382,28 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'Add Contact to Segment',
       description:
-        'Add a contact to a segment in Resend (by contact ID or email).',
+        'Add a contact to a segment in Resend (by contact ID, dashboard URL, or email).',
       inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
+        contactId: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         segmentId: z
           .string()
           .nonempty()
-          .describe('Segment ID to add the contact to'),
+          .describe(
+            'Segment ID or Resend dashboard URL (e.g. https://resend.com/audience/segments/<id>)',
+          ),
       },
     },
-    async ({ contactId, email, segmentId }) => {
+    async ({ contactId: rawContactId, email, segmentId: rawSegmentId }) => {
+      const segmentId = extractIdFromUrl(rawSegmentId, 'audience/segments');
       let response;
-      if (contactId) {
+      if (rawContactId) {
+        const contactId = extractIdFromUrl(rawContactId, 'audience/contacts');
         response = await resend.contacts.segments.add({ contactId, segmentId });
       } else if (email) {
         response = await resend.contacts.segments.add({ email, segmentId });
@@ -403,19 +433,28 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Contact from Segment',
       description:
-        'Remove a contact from a segment in Resend (by contact ID or email). Before using this tool, you MUST double-check with the user that they want to remove the contact from the segment.',
+        'Remove a contact from a segment in Resend (by contact ID, dashboard URL, or email). Before using this tool, you MUST double-check with the user that they want to remove the contact from the segment.',
       inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
+        contactId: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         segmentId: z
           .string()
           .nonempty()
-          .describe('Segment ID to remove the contact from'),
+          .describe(
+            'Segment ID or Resend dashboard URL (e.g. https://resend.com/audience/segments/<id>)',
+          ),
       },
     },
-    async ({ contactId, email, segmentId }) => {
+    async ({ contactId: rawContactId, email, segmentId: rawSegmentId }) => {
+      const segmentId = extractIdFromUrl(rawSegmentId, 'audience/segments');
       let response;
-      if (contactId) {
+      if (rawContactId) {
+        const contactId = extractIdFromUrl(rawContactId, 'audience/contacts');
         response = await resend.contacts.segments.remove({
           contactId,
           segmentId,
@@ -448,9 +487,14 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'List Contact Segments',
       description:
-        "List all segments a contact belongs to in Resend (by contact ID or email). Don't bother telling the user the IDs or creation dates unless they ask for them.",
+        "List all segments a contact belongs to in Resend (by contact ID, dashboard URL, or email). Don't bother telling the user the IDs or creation dates unless they ask for them.",
       inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
+        contactId: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         limit: z
           .number()
@@ -474,20 +518,22 @@ export function addContactTools(server: McpServer, resend: Resend) {
           ),
       },
     },
-    async ({ contactId, email, limit, after, before }) => {
+    async ({ contactId: rawContactId, email, limit, after, before }) => {
       if (after && before) {
         throw new Error(
           'Cannot use both "after" and "before" parameters. Use only one for pagination.',
         );
       }
 
-      if (!contactId && !email) {
+      if (!rawContactId && !email) {
         throw new Error(
           'You must provide either `contactId` or `email` to list contact segments.',
         );
       }
 
-      const contactField = contactId ? { contactId } : { email: email! };
+      const contactField = rawContactId
+        ? { contactId: extractIdFromUrl(rawContactId, 'audience/contacts') }
+        : { email: email! };
 
       const paginationOptions = after
         ? { limit, after }
@@ -545,9 +591,14 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'List Contact Topics',
       description:
-        "List all topic subscriptions for a contact in Resend (by contact ID or email). Don't bother telling the user the IDs unless they ask for them.",
+        "List all topic subscriptions for a contact in Resend (by contact ID, dashboard URL, or email). Don't bother telling the user the IDs unless they ask for them.",
       inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         limit: z
           .number()
@@ -571,20 +622,22 @@ export function addContactTools(server: McpServer, resend: Resend) {
           ),
       },
     },
-    async ({ id, email, limit, after, before }) => {
+    async ({ id: rawId, email, limit, after, before }) => {
       if (after && before) {
         throw new Error(
           'Cannot use both "after" and "before" parameters. Use only one for pagination.',
         );
       }
 
-      if (!id && !email) {
+      if (!rawId && !email) {
         throw new Error(
           'You must provide either `id` or `email` to list contact topics.',
         );
       }
 
-      const contactField = id ? { id } : { email: email! };
+      const contactField = rawId
+        ? { id: extractIdFromUrl(rawId, 'audience/contacts') }
+        : { email: email! };
 
       const paginationOptions = after
         ? { limit, after }
@@ -651,9 +704,14 @@ export function addContactTools(server: McpServer, resend: Resend) {
     {
       title: 'Update Contact Topics',
       description:
-        'Update topic subscriptions for a contact in Resend (by contact ID or email).',
+        'Update topic subscriptions for a contact in Resend (by contact ID, dashboard URL, or email).',
       inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Contact ID or Resend dashboard URL (e.g. https://resend.com/audience/contacts/<id>)',
+          ),
         email: z.email().optional().describe('Contact email address'),
         topics: z
           .array(
@@ -668,14 +726,16 @@ export function addContactTools(server: McpServer, resend: Resend) {
           .describe('Array of topic subscription configurations to update'),
       },
     },
-    async ({ id, email, topics }) => {
-      if (!id && !email) {
+    async ({ id: rawId, email, topics }) => {
+      if (!rawId && !email) {
         throw new Error(
           'You must provide either `id` or `email` to update contact topics.',
         );
       }
 
-      const contactField = id ? { id } : { email: email! };
+      const contactField = rawId
+        ? { id: extractIdFromUrl(rawId, 'audience/contacts') }
+        : { email: email! };
 
       const response = await resend.contacts.topics.update({
         ...contactField,

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 function formatDnsRecords(
   records: {
@@ -209,12 +210,18 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     {
       title: 'Get Domain',
       description:
-        'Get a domain by ID from Resend. Returns full domain details including DNS records needed for verification.',
+        'Get a domain by ID or dashboard URL from Resend. Returns full domain details including DNS records needed for verification.',
       inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Domain ID or Resend dashboard URL (e.g. https://resend.com/domains/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'domains');
       const response = await resend.domains.get(id);
 
       if (response.error) {
@@ -244,9 +251,14 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     {
       title: 'Update Domain',
       description:
-        'Update an existing domain in Resend. Allows changing tracking settings, TLS mode, and capabilities.',
+        'Update an existing domain in Resend. Accepts a domain ID or dashboard URL. Allows changing tracking settings, TLS mode, and capabilities.',
       inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Domain ID or Resend dashboard URL (e.g. https://resend.com/domains/<id>)',
+          ),
         clickTracking: z
           .boolean()
           .optional()
@@ -278,7 +290,8 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           ),
       },
     },
-    async ({ id, clickTracking, openTracking, tls, capabilities }) => {
+    async ({ id: rawId, clickTracking, openTracking, tls, capabilities }) => {
+      const id = extractIdFromUrl(rawId, 'domains');
       const response = await resend.domains.update({
         id,
         ...(clickTracking !== undefined && { clickTracking }),
@@ -307,12 +320,18 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Domain',
       description:
-        'Remove a domain by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this domain. Reference the NAME of the domain when double-checking, and warn the user that removing a domain is irreversible and will stop all email sending/receiving for that domain. You may only use this tool if the user explicitly confirms they want to remove the domain after you double-check.',
+        'Remove a domain by ID or dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this domain. Reference the NAME of the domain when double-checking, and warn the user that removing a domain is irreversible and will stop all email sending/receiving for that domain. You may only use this tool if the user explicitly confirms they want to remove the domain after you double-check.',
       inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Domain ID or Resend dashboard URL (e.g. https://resend.com/domains/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'domains');
       const response = await resend.domains.remove(id);
 
       if (response.error) {
@@ -335,12 +354,18 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     {
       title: 'Verify Domain',
       description:
-        'Trigger domain verification in Resend. This starts an asynchronous verification process that checks if the DNS records are correctly configured. The domain status will temporarily show as "pending" during verification.',
+        'Trigger domain verification in Resend. Accepts a domain ID or dashboard URL. This starts an asynchronous verification process that checks if the DNS records are correctly configured. The domain status will temporarily show as "pending" during verification.',
       inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Domain ID or Resend dashboard URL (e.g. https://resend.com/domains/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'domains');
       const response = await resend.domains.verify(id);
 
       if (response.error) {

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addEmailTools(
   server: McpServer,
@@ -387,12 +388,17 @@ export function addEmailTools(
     {
       title: 'Get Email',
       description:
-        'Retrieve full details of a specific sent transactional email by ID, including HTML and plain text content.',
+        'Retrieve full details of a specific sent transactional email by ID or dashboard URL, including HTML and plain text content.',
       inputSchema: {
-        id: z.string().describe('The email ID to retrieve'),
+        id: z
+          .string()
+          .describe(
+            'Email ID or Resend dashboard URL (e.g. https://resend.com/emails/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'emails');
       const response = await resend.emails.get(id);
 
       if (response.error) {
@@ -756,12 +762,17 @@ export function addEmailTools(
     {
       title: 'Cancel Email',
       description:
-        'Cancel a scheduled email that has not yet been sent. Only works for emails that were scheduled using the scheduledAt parameter.',
+        'Cancel a scheduled email that has not yet been sent. Accepts an email ID or dashboard URL. Only works for emails that were scheduled using the scheduledAt parameter.',
       inputSchema: {
-        id: z.string().describe('The ID of the scheduled email to cancel'),
+        id: z
+          .string()
+          .describe(
+            'Email ID or Resend dashboard URL (e.g. https://resend.com/emails/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'emails');
       const response = await resend.emails.cancel(id);
 
       if (response.error) {
@@ -786,9 +797,13 @@ export function addEmailTools(
     {
       title: 'Update Email',
       description:
-        'Reschedule a scheduled email by updating its scheduled send time. Only works for emails that were scheduled and have not yet been sent.',
+        'Reschedule a scheduled email by updating its scheduled send time. Accepts an email ID or dashboard URL. Only works for emails that were scheduled and have not yet been sent.',
       inputSchema: {
-        id: z.string().describe('The ID of the scheduled email to update'),
+        id: z
+          .string()
+          .describe(
+            'Email ID or Resend dashboard URL (e.g. https://resend.com/emails/<id>)',
+          ),
         scheduledAt: z
           .string()
           .describe(
@@ -796,7 +811,8 @@ export function addEmailTools(
           ),
       },
     },
-    async ({ id, scheduledAt }) => {
+    async ({ id: rawId, scheduledAt }) => {
+      const id = extractIdFromUrl(rawId, 'emails');
       const response = await resend.emails.update({ id, scheduledAt });
 
       if (response.error) {

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addLogTools(server: McpServer, resend: Resend) {
   server.registerTool(
@@ -106,7 +107,7 @@ export function addLogTools(server: McpServer, resend: Resend) {
     'get-log',
     {
       title: 'Get Log',
-      description: `**Purpose:** Get detailed information about a specific API request log, including the full request and response bodies.
+      description: `**Purpose:** Get detailed information about a specific API request log by ID or dashboard URL, including the full request and response bodies.
 
 **Returns:** Log details: id, created_at, endpoint, method, response_status, user_agent, request_body, response_body.
 
@@ -115,10 +116,16 @@ export function addLogTools(server: McpServer, resend: Resend) {
 - Debugging a particular API call
 - User says "show me that log", "what was in that request?"`,
       inputSchema: {
-        logId: z.string().nonempty().describe('The Log ID to retrieve'),
+        logId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Log ID or Resend dashboard URL (e.g. https://resend.com/logs/<id>)',
+          ),
       },
     },
-    async ({ logId }) => {
+    async ({ logId: rawLogId }) => {
+      const logId = extractIdFromUrl(rawLogId, 'logs');
       const response = await resend.logs.get(logId);
 
       if (response.error) {

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addSegmentTools(server: McpServer, resend: Resend) {
   server.registerTool(
@@ -125,12 +126,19 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     'get-segment',
     {
       title: 'Get Segment',
-      description: 'Get a segment by ID from Resend.',
+      description:
+        'Get a segment by ID or dashboard URL from Resend.',
       inputSchema: {
-        id: z.string().nonempty().describe('Segment ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Segment ID or Resend dashboard URL (e.g. https://resend.com/audience/segments/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'audience/segments');
       const response = await resend.segments.get(id);
 
       if (response.error) {
@@ -156,12 +164,18 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Segment',
       description:
-        'Remove a segment by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this segment. Reference the NAME of the segment when double-checking, and warn the user that removing a segment is irreversible. You may only use this tool if the user explicitly confirms they want to remove the segment after you double-check.',
+        'Remove a segment by ID or dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this segment. Reference the NAME of the segment when double-checking, and warn the user that removing a segment is irreversible. You may only use this tool if the user explicitly confirms they want to remove the segment after you double-check.',
       inputSchema: {
-        id: z.string().nonempty().describe('Segment ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Segment ID or Resend dashboard URL (e.g. https://resend.com/audience/segments/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'audience/segments');
       const response = await resend.segments.remove(id);
 
       if (response.error) {

--- a/src/tools/topics.ts
+++ b/src/tools/topics.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 export function addTopicTools(server: McpServer, resend: Resend) {
   server.registerTool(
@@ -94,12 +95,19 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     'get-topic',
     {
       title: 'Get Topic',
-      description: 'Get a topic by ID from Resend.',
+      description:
+        'Get a topic by ID or dashboard URL from Resend.',
       inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Topic ID or Resend dashboard URL (e.g. https://resend.com/audience/topics/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'audience/topics');
       const response = await resend.topics.get(id);
 
       if (response.error) {
@@ -130,9 +138,14 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     {
       title: 'Update Topic',
       description:
-        'Update an existing topic in Resend. Note: defaultSubscription cannot be modified after creation.',
+        'Update an existing topic in Resend. Accepts a topic ID or dashboard URL. Note: defaultSubscription cannot be modified after creation.',
       inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Topic ID or Resend dashboard URL (e.g. https://resend.com/audience/topics/<id>)',
+          ),
         name: z
           .string()
           .nonempty()
@@ -146,7 +159,8 @@ export function addTopicTools(server: McpServer, resend: Resend) {
           .describe('New topic description (max 200 characters)'),
       },
     },
-    async ({ id, name, description }) => {
+    async ({ id: rawId, name, description }) => {
+      const id = extractIdFromUrl(rawId, 'audience/topics');
       const response = await resend.topics.update({
         id,
         ...(name && { name }),
@@ -173,12 +187,18 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Topic',
       description:
-        'Remove a topic by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this topic. Reference the NAME of the topic when double-checking, and warn the user that removing a topic is irreversible. You may only use this tool if the user explicitly confirms they want to remove the topic after you double-check.',
+        'Remove a topic by ID or dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this topic. Reference the NAME of the topic when double-checking, and warn the user that removing a topic is irreversible. You may only use this tool if the user explicitly confirms they want to remove the topic after you double-check.',
       inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Topic ID or Resend dashboard URL (e.g. https://resend.com/audience/topics/<id>)',
+          ),
       },
     },
-    async ({ id }) => {
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'audience/topics');
       const response = await resend.topics.remove(id);
 
       if (response.error) {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
+import { extractIdFromUrl } from '../lib/url-parser.js';
 
 const webhookEventSchema = z.enum([
   'email.sent',
@@ -100,12 +101,19 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     'get-webhook',
     {
       title: 'Get Webhook',
-      description: 'Get a webhook by ID from Resend.',
+      description:
+        'Get a webhook by ID or dashboard URL from Resend.',
       inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
+        webhookId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Webhook ID or Resend dashboard URL (e.g. https://resend.com/webhooks/<id>)',
+          ),
       },
     },
-    async ({ webhookId }) => {
+    async ({ webhookId: rawWebhookId }) => {
+      const webhookId = extractIdFromUrl(rawWebhookId, 'webhooks');
       const response = await resend.webhooks.get(webhookId);
 
       if (response.error) {
@@ -131,9 +139,14 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     {
       title: 'Update Webhook',
       description:
-        'Update an existing webhook in Resend. You can change the endpoint URL, subscribed events, or enable/disable the webhook.',
+        'Update an existing webhook in Resend. Accepts a webhook ID or dashboard URL. You can change the endpoint URL, subscribed events, or enable/disable the webhook.',
       inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
+        webhookId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Webhook ID or Resend dashboard URL (e.g. https://resend.com/webhooks/<id>)',
+          ),
         endpoint: z
           .url()
           .optional()
@@ -149,7 +162,8 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
           .describe('Webhook status'),
       },
     },
-    async ({ webhookId, endpoint, events, status }) => {
+    async ({ webhookId: rawWebhookId, endpoint, events, status }) => {
+      const webhookId = extractIdFromUrl(rawWebhookId, 'webhooks');
       const response = await resend.webhooks.update(webhookId, {
         endpoint,
         events,
@@ -176,12 +190,18 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     {
       title: 'Remove Webhook',
       description:
-        'Remove a webhook by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this webhook. Reference the ENDPOINT of the webhook when double-checking, and warn the user that removing a webhook is irreversible. You may only use this tool if the user explicitly confirms they want to remove the webhook after you double-check.',
+        'Remove a webhook by ID or dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this webhook. Reference the ENDPOINT of the webhook when double-checking, and warn the user that removing a webhook is irreversible. You may only use this tool if the user explicitly confirms they want to remove the webhook after you double-check.',
       inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
+        webhookId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Webhook ID or Resend dashboard URL (e.g. https://resend.com/webhooks/<id>)',
+          ),
       },
     },
-    async ({ webhookId }) => {
+    async ({ webhookId: rawWebhookId }) => {
+      const webhookId = extractIdFromUrl(rawWebhookId, 'webhooks');
       const response = await resend.webhooks.remove(webhookId);
 
       if (response.error) {

--- a/tests/lib/url-parser.test.ts
+++ b/tests/lib/url-parser.test.ts
@@ -56,7 +56,7 @@ describe('extractIdFromUrl', () => {
 
   it('throws for unsupported resend.com resource paths', () => {
     expect(() =>
-      extractIdFromUrl('https://resend.com/domains/some-id'),
+      extractIdFromUrl('https://resend.com/settings/some-id'),
     ).toThrow(/unsupported resource type/i);
   });
 
@@ -64,6 +64,107 @@ describe('extractIdFromUrl', () => {
     expect(extractIdFromUrl('https://resend.com/broadcasts/abc-123')).toBe(
       'abc-123',
     );
+  });
+
+  // New simple resource types
+  it('extracts domain ID from URL', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/domains/dom-123', 'domains'),
+    ).toBe('dom-123');
+  });
+
+  it('extracts API key ID from URL', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/api-keys/key-456', 'api-keys'),
+    ).toBe('key-456');
+  });
+
+  it('extracts webhook ID from URL', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/webhooks/wh-789', 'webhooks'),
+    ).toBe('wh-789');
+  });
+
+  it('extracts log ID from URL', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/logs/log-001', 'logs'),
+    ).toBe('log-001');
+  });
+
+  it('extracts email ID from URL', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/emails/em-999', 'emails'),
+    ).toBe('em-999');
+  });
+
+  // Nested resource types (audience/*)
+  it('extracts contact ID from nested audience URL', () => {
+    expect(
+      extractIdFromUrl(
+        'https://resend.com/audience/contacts/ct-123',
+        'audience/contacts',
+      ),
+    ).toBe('ct-123');
+  });
+
+  it('extracts segment ID from nested audience URL', () => {
+    expect(
+      extractIdFromUrl(
+        'https://resend.com/audience/segments/seg-456',
+        'audience/segments',
+      ),
+    ).toBe('seg-456');
+  });
+
+  it('extracts topic ID from nested audience URL', () => {
+    expect(
+      extractIdFromUrl(
+        'https://resend.com/audience/topics/top-789',
+        'audience/topics',
+      ),
+    ).toBe('top-789');
+  });
+
+  it('handles nested URLs with trailing slash', () => {
+    expect(
+      extractIdFromUrl(
+        'https://resend.com/audience/contacts/ct-123/',
+        'audience/contacts',
+      ),
+    ).toBe('ct-123');
+  });
+
+  it('handles nested URLs with query parameters', () => {
+    expect(
+      extractIdFromUrl(
+        'https://resend.com/audience/segments/seg-456?tab=details',
+        'audience/segments',
+      ),
+    ).toBe('seg-456');
+  });
+
+  it('throws for mismatched nested resource type', () => {
+    expect(() =>
+      extractIdFromUrl(
+        'https://resend.com/audience/contacts/ct-123',
+        'audience/segments',
+      ),
+    ).toThrow(/expected a audience\/segments URL/i);
+  });
+
+  it('throws when expecting nested resource but getting simple resource', () => {
+    expect(() =>
+      extractIdFromUrl(
+        'https://resend.com/domains/dom-123',
+        'audience/contacts',
+      ),
+    ).toThrow(/expected a audience\/contacts URL/i);
+  });
+
+  it('extracts nested ID without expectedResource filter', () => {
+    expect(
+      extractIdFromUrl('https://resend.com/audience/contacts/ct-123'),
+    ).toBe('ct-123');
   });
 
   it('trims whitespace from input', () => {


### PR DESCRIPTION
## Summary
- Extends `extractIdFromUrl` to support all resource types: domains, api-keys, webhooks, logs, emails, and nested audience paths (contacts, segments, topics)
- Updates every tool that accepts a resource ID to also accept a Resend dashboard URL
- Adds 14 new test cases covering simple resources, nested paths, and error scenarios

Follows up on #119 which added URL parsing for broadcasts, templates, and automations.