### PR TITLE
feat: add custom tracking domain support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dotenv": "17.3.1",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.11.0",
+    "resend": "6.12.0",
     "zod": "4.3.6"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.11.0
-        version: 6.11.0(@react-email/render@1.1.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        specifier: 6.12.0
+        version: 6.12.0(@react-email/render@1.1.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -895,8 +895,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.11.0:
-    resolution: {integrity: sha512-S9gxOccfwc+E6Cr3q28Gu8NkiIjYlYPlj9rqk4zkIuzlEoh8sWu/IvJSg7U7t+o3g0Ov2IOCzcneUaCi/M/WdQ==}
+  resend@6.12.0:
+    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1854,7 +1854,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resend@6.11.0(@react-email/render@1.1.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  resend@6.12.0(@react-email/render@1.1.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       postal-mime: 2.7.4
       svix: 1.90.0

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -59,6 +59,12 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           .describe(
             'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails. Defaults to "opportunistic".',
           ),
+        trackingSubdomain: z
+          .string()
+          .optional()
+          .describe(
+            'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
+          ),
         capabilities: z
           .object({
             sending: z
@@ -81,6 +87,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
       openTracking,
       clickTracking,
       tls,
+      trackingSubdomain,
       capabilities,
     }) => {
       const response = await resend.domains.create({
@@ -90,6 +97,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
         ...(openTracking !== undefined && { openTracking }),
         ...(clickTracking !== undefined && { clickTracking }),
         ...(tls && { tls }),
+        ...(trackingSubdomain && { trackingSubdomain }),
         ...(capabilities && { capabilities }),
       });
 
@@ -105,7 +113,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           { type: 'text', text: 'Domain created successfully.' },
           {
             type: 'text',
-            text: `Name: ${created.name}\nID: ${created.id}\nStatus: ${created.status}\nRegion: ${created.region}`,
+            text: `Name: ${created.name}\nID: ${created.id}\nStatus: ${created.status}\nRegion: ${created.region}\nOpen Tracking: ${created.open_tracking ?? false}\nClick Tracking: ${created.click_tracking ?? false}${created.tracking_subdomain ? `\nTracking Subdomain: ${created.tracking_subdomain}` : ''}`,
           },
           {
             type: 'text',
@@ -189,7 +197,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           },
           ...domains.map((domain) => ({
             type: 'text' as const,
-            text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nCreated at: ${domain.created_at}`,
+            text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nOpen Tracking: ${domain.open_tracking ?? false}\nClick Tracking: ${domain.click_tracking ?? false}${domain.tracking_subdomain ? `\nTracking Subdomain: ${domain.tracking_subdomain}` : ''}\nCreated at: ${domain.created_at}`,
           })),
           ...(hasMore
             ? [
@@ -228,7 +236,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
         content: [
           {
             type: 'text',
-            text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nCreated at: ${domain.created_at}`,
+            text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nOpen Tracking: ${domain.open_tracking ?? false}\nClick Tracking: ${domain.click_tracking ?? false}${domain.tracking_subdomain ? `\nTracking Subdomain: ${domain.tracking_subdomain}` : ''}\nCreated at: ${domain.created_at}`,
           },
           {
             type: 'text',
@@ -261,6 +269,12 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           .describe(
             'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails.',
           ),
+        trackingSubdomain: z
+          .string()
+          .optional()
+          .describe(
+            'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
+          ),
         capabilities: z
           .object({
             sending: z
@@ -278,12 +292,20 @@ export function addDomainTools(server: McpServer, resend: Resend) {
           ),
       },
     },
-    async ({ id, clickTracking, openTracking, tls, capabilities }) => {
+    async ({
+      id,
+      clickTracking,
+      openTracking,
+      tls,
+      trackingSubdomain,
+      capabilities,
+    }) => {
       const response = await resend.domains.update({
         id,
         ...(clickTracking !== undefined && { clickTracking }),
         ...(openTracking !== undefined && { openTracking }),
         ...(tls && { tls }),
+        ...(trackingSubdomain && { trackingSubdomain }),
         ...(capabilities && { capabilities }),
       });
 


### PR DESCRIPTION
Adds trackingSubdomain parameter to create-domain and update-domain tools, and surfaces tracking settings (open/click tracking, tracking subdomain) in domain responses.