### PR TITLE
chore: harden workflow permissions and add job timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   build:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
     container:
       image: node:24
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   lint:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
     container:
       image: node:24
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   pin-dependencies-check:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
     container:
       image: node:24-slim
     steps:

--- a/.github/workflows/pull-request-title-check.yml
+++ b/.github/workflows/pull-request-title-check.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   pull-request-title-check:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
     container:
       image: node:24-slim
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,11 @@ on:
 concurrency:
   group: release
   cancel-in-progress: false
+permissions: {}
 jobs:
   ci:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
     container:
       image: node:24
     steps:
@@ -26,6 +28,7 @@ jobs:
   release:
     needs: ci
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:
@@ -48,6 +51,7 @@ jobs:
   publish-npm:
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
- release.yml: add deny-by-default top-level permissions (per-job perms preserved)
- add timeout-minutes to all 7 jobs across release, build, lint, pin-dependencies-check, and pull-request-title-check workflows