### PR TITLE
chore: require node 22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "zod": "4.4.3"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=20` to `>=22`.

Node 20 is approaching EOL and the in-flight pnpm 11 bump (#140) requires Node 22+, so this aligns our declared minimum before that lands.

## Test plan
- [ ] CI passes on Node 24 (existing workflow runner).