### PR TITLE
feat: better order of validation for command running

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -13,6 +13,7 @@ Options:
   --http                   Run HTTP server (Streamable HTTP at /mcp) instead of stdio
   --port <number>          HTTP port when using --http (default: 3000, or MCP_PORT)
   -h, --help               Show this help
+  -v, --version            Show the installed version
 
 Environment:
   RESEND_API_KEY           Required if --key not set

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,28 @@
 import type { ParsedArgs } from 'minimist';
+import packageJson from '../../package.json' with { type: 'json' };
+import { CLI_STRING_OPTIONS } from './constants.js';
 import { printHelp } from './help.js';
 import { resolveConfig } from './resolve.js';
 import type { CliConfig } from './types.js';
+
+const KNOWN_ARG_KEYS = new Set([
+  '_',
+  ...CLI_STRING_OPTIONS,
+  'h',
+  'help',
+  'http',
+  'v',
+  'version',
+]);
+
+function getUnknownArgs(argv: ParsedArgs): string[] {
+  const unknownOptions = Object.keys(argv)
+    .filter((key) => !KNOWN_ARG_KEYS.has(key))
+    .map((key) => (key.length === 1 ? `-${key}` : `--${key}`));
+  const positionalArgs = Array.isArray(argv._) ? argv._.map(String) : [];
+
+  return [...unknownOptions, ...positionalArgs];
+}
 
 /**
  * Resolve config from argv and env, or print help/error and exit.
@@ -13,6 +34,17 @@ export function resolveConfigOrExit(
   if (argv.help === true || argv.h === true) {
     printHelp();
     process.exit(0);
+  }
+
+  if (argv.version === true || argv.v === true) {
+    console.log(packageJson.version);
+    process.exit(0);
+  }
+
+  const unknownArgs = getUnknownArgs(argv);
+  if (unknownArgs.length > 0) {
+    console.error('Error:', `Unknown option: ${unknownArgs[0]}`);
+    process.exit(1);
   }
 
   const result = resolveConfig(argv, env);

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -8,8 +8,8 @@ import { CLI_STRING_OPTIONS } from './constants.js';
 export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   return minimist(argv, {
     string: [...CLI_STRING_OPTIONS],
-    boolean: ['help', 'http'],
-    alias: { h: 'help' },
+    boolean: ['help', 'http', 'version'],
+    alias: { h: 'help', v: 'version' },
   });
 }
 

--- a/tests/cli/help.test.ts
+++ b/tests/cli/help.test.ts
@@ -11,6 +11,7 @@ describe('help', () => {
     expect(HELP_TEXT).toContain('--http');
     expect(HELP_TEXT).toContain('--port');
     expect(HELP_TEXT).toContain('-h, --help');
+    expect(HELP_TEXT).toContain('-v, --version');
     expect(HELP_TEXT).toContain('RESEND_API_KEY');
     expect(HELP_TEXT).toContain('MCP_PORT');
   });

--- a/tests/cli/parse.test.ts
+++ b/tests/cli/parse.test.ts
@@ -26,6 +26,11 @@ describe('parseArgs', () => {
     expect(parseArgs(['--help']).help).toBe(true);
   });
 
+  it('parses -v and --version', () => {
+    expect(parseArgs(['-v']).version).toBe(true);
+    expect(parseArgs(['--version']).version).toBe(true);
+  });
+
   it('parses single --reply-to', () => {
     const parsed = parseArgs(['--reply-to', 'reply@example.com']);
     expect(parsed['reply-to']).toBe('reply@example.com');

--- a/tests/cli/resolveConfigOrExit.test.ts
+++ b/tests/cli/resolveConfigOrExit.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import packageJson from '../../package.json' with { type: 'json' };
 import { resolveConfigOrExit } from '../../src/cli/index.js';
 import { parseArgs } from '../../src/cli/parse.js';
 
 describe('resolveConfigOrExit', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     exitSpy = vi
@@ -13,11 +15,13 @@ describe('resolveConfigOrExit', () => {
         throw new Error(`process.exit(${code})`);
       }) as ReturnType<typeof vi.spyOn>;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
     exitSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
   });
 
   it('calls process.exit(0) and prints help when --help', () => {
@@ -34,6 +38,29 @@ describe('resolveConfigOrExit', () => {
   it('calls process.exit(0) when -h', () => {
     expect(() => resolveConfigOrExit(parseArgs(['-h']), {})).toThrow();
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('calls process.exit(0) and prints version when --version', () => {
+    expect(() => resolveConfigOrExit(parseArgs(['--version']), {})).toThrow();
+    expect(consoleLogSpy).toHaveBeenCalledWith(packageJson.version);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('calls process.exit(0) and prints version when -v', () => {
+    expect(() => resolveConfigOrExit(parseArgs(['-v']), {})).toThrow();
+    expect(consoleLogSpy).toHaveBeenCalledWith(packageJson.version);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('reports unknown flags before API key validation', () => {
+    expect(() =>
+      resolveConfigOrExit(parseArgs(['--definitely-not-a-real-flag']), {}),
+    ).toThrow();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error:',
+      'Unknown option: --definitely-not-a-real-flag',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('calls process.exit(1) and console.error when config invalid', () => {


### PR DESCRIPTION
## Summary
- add `--version` / `-v` handling before API key validation
- report unknown CLI flags before config validation so they do not get masked by missing API-key errors
- document the version flag and cover the behavior in CLI tests

## Test plan
- `pnpm test tests/cli/parse.test.ts tests/cli/help.test.ts tests/cli/resolveConfigOrExit.test.ts`
- `pnpm build`
- `env -u RESEND_API_KEY node dist/index.js --version`
- `env -u RESEND_API_KEY node dist/index.js -v`
- `env -u RESEND_API_KEY node dist/index.js --definitely-not-a-real-flag`
- `env -u RESEND_API_KEY node dist/index.js`
- `pnpm lint`
- `pnpm test`