### PR TITLE
chore: expose resend-mcp/http runHttp server helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ You can also set the port via the `MCP_PORT` environment variable:
 MCP_PORT=3000 npx -y resend-mcp --http
 ```
 
+#### Use as a library
+
+The HTTP transport is also exported so it can be embedded in another service instead of being run via the CLI. Each connecting client authenticates with its own Resend API key passed as a Bearer token.
+
+```ts
+import { runHttp } from 'resend-mcp/http';
+
+// Options are optional — pass `senderEmailAddress` / `replierEmailAddresses`
+// to set defaults. Binds the port and returns the Node http.Server, exposing
+// the MCP endpoint at POST/GET/DELETE /mcp and a GET /health check.
+const server = await runHttp({}, 3000);
+```
+
 ### Options
 
 You can pass additional arguments to configure the server:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,18 @@
   "bin": {
     "resend-mcp": "dist/index.js"
   },
+  "main": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./http": {
+      "types": "./dist/transports/http.d.ts",
+      "default": "./dist/transports/http.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ export function createMcpServer(
   options: ServerOptions,
   apiKey: string,
 ): McpServer {
-  const { senderEmailAddress, replierEmailAddresses } = options;
+  const { senderEmailAddress, replierEmailAddresses = [] } = options;
   const server = new McpServer({
     name: 'resend',
     version: packageJson.version,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
 export interface ServerOptions {
   senderEmailAddress?: string;
-  replierEmailAddresses: string[];
+  replierEmailAddresses?: string[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "jsx": "react-jsx",
+    "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Exposing runHttp for use in the MCP hosted server service, not adding the option to create custom tools yet, that comes later. With this PR we can install and use in any nodejs service as a thin wrapper:

```
import { runHttp } from 'resend-mcp/http';

// Options are optional — pass `senderEmailAddress` / `replierEmailAddresses`
// to set defaults. Binds the port and returns the Node http.Server, exposing
// the MCP endpoint at POST/GET/DELETE /mcp and a GET /health check.
const server = await runHttp({}, 3000);
```

We are also updating package json to export types and configure exports aliases, now that the mcp will be used as a lib it matters.
