### PR TITLE
feat(http): configurable host/allowedHosts for DNS-rebinding protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ import { runHttp } from 'resend-mcp/http';
 const server = await runHttp({}, 3000);
 ```
 
+By default the server applies localhost-only `Host` validation (DNS-rebinding
+protection). When deploying behind a reverse proxy or load balancer — where the
+server is protected by the per-request Bearer API key — set `host` to `0.0.0.0`
+so the proxy's forwarded `Host` and load-balancer health checks aren't rejected
+with `403 Invalid Host`:
+
+```ts
+const server = await runHttp({}, 3000, { host: '0.0.0.0' });
+// or pin specific hostnames instead of disabling validation:
+const server = await runHttp({}, 3000, { allowedHosts: ['mcp.example.com'] });
+```
+
+Via the CLI this maps to `--host` / `--allowed-hosts` (or `MCP_HOST` /
+`MCP_ALLOWED_HOSTS`).
+
 ### Options
 
 You can pass additional arguments to configure the server:
@@ -143,6 +158,8 @@ You can pass additional arguments to configure the server:
 - `--reply-to`: Default reply-to email address (can be specified multiple times)
 - `--http`: Use HTTP transport instead of stdio (default: stdio)
 - `--port`: HTTP port when using `--http` (default: 3000, or `MCP_PORT` env var)
+- `--host`: Host for DNS-rebinding protection when using `--http` (default: `127.0.0.1`, or `MCP_HOST`). Set to `0.0.0.0` to disable `Host` validation behind a proxy/load balancer.
+- `--allowed-hosts`: Comma-separated `Host` allow-list when using `--http` (or `MCP_ALLOWED_HOSTS`)
 
 Environment variables:
 
@@ -150,6 +167,8 @@ Environment variables:
 - `SENDER_EMAIL_ADDRESS`: Default sender email address from a verified domain (optional)
 - `REPLY_TO_EMAIL_ADDRESSES`: Comma-separated reply-to email addresses (optional)
 - `MCP_PORT`: HTTP port when using `--http` (optional)
+- `MCP_HOST`: Host for DNS-rebinding protection when using `--http` (optional)
+- `MCP_ALLOWED_HOSTS`: Comma-separated `Host` allow-list when using `--http` (optional)
 
 > [!NOTE]
 > If you don't provide a sender email address, the MCP server will ask you to provide one each time you call the tool.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -3,6 +3,8 @@ export const CLI_STRING_OPTIONS = [
   'sender',
   'reply-to',
   'port',
+  'host',
+  'allowed-hosts',
 ] as const;
 
 export const DEFAULT_HTTP_PORT = 3000;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -12,6 +12,9 @@ Options:
   --reply-to <email>       Reply-to; repeat for multiple (or REPLY_TO_EMAIL_ADDRESSES)
   --http                   Run HTTP server (Streamable HTTP at /mcp) instead of stdio
   --port <number>          HTTP port when using --http (default: 3000, or MCP_PORT)
+  --host <host>            Host for DNS-rebinding protection (default: 127.0.0.1, or MCP_HOST).
+                           Use 0.0.0.0 to disable Host validation behind a proxy/load balancer.
+  --allowed-hosts <list>   Comma-separated Host allow-list (or MCP_ALLOWED_HOSTS)
   -h, --help               Show this help
 
 Environment:
@@ -19,6 +22,8 @@ Environment:
   SENDER_EMAIL_ADDRESS     Optional
   REPLY_TO_EMAIL_ADDRESSES Optional, comma-separated
   MCP_PORT                 HTTP port when using --http (optional)
+  MCP_HOST                 Host for DNS-rebinding protection when using --http (optional)
+  MCP_ALLOWED_HOSTS        Comma-separated Host allow-list when using --http (optional)
 `.trim();
 
 export function printHelp(): void {

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -31,3 +31,30 @@ export function parseReplierAddresses(
   }
   return [];
 }
+
+/**
+ * Parse the allowed-hosts list from argv and env. argv wins. Returns undefined
+ * when neither is set, so the SDK's host-based default applies.
+ */
+export function parseAllowedHosts(
+  parsed: ParsedArgs,
+  env: NodeJS.ProcessEnv,
+): string[] | undefined {
+  if (Array.isArray(parsed['allowed-hosts'])) return parsed['allowed-hosts'];
+  if (typeof parsed['allowed-hosts'] === 'string') {
+    const list = parsed['allowed-hosts']
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return list.length ? list : undefined;
+  }
+  const v = env.MCP_ALLOWED_HOSTS;
+  if (typeof v === 'string' && v.trim()) {
+    const list = v
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return list.length ? list : undefined;
+  }
+  return undefined;
+}

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -1,7 +1,18 @@
 import type { ParsedArgs } from 'minimist';
 import { DEFAULT_HTTP_PORT } from './constants.js';
-import { parseReplierAddresses } from './parse.js';
+import { parseAllowedHosts, parseReplierAddresses } from './parse.js';
 import type { ResolveResult } from './types.js';
+
+function resolveHost(
+  parsed: ParsedArgs,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  if (typeof parsed.host === 'string' && parsed.host.trim() !== '')
+    return parsed.host.trim();
+  if (typeof env.MCP_HOST === 'string' && env.MCP_HOST.trim() !== '')
+    return env.MCP_HOST.trim();
+  return undefined;
+}
 
 function parsePort(parsed: ParsedArgs, env: NodeJS.ProcessEnv): number {
   const fromArg =
@@ -60,7 +71,13 @@ export function resolveConfig(
   return {
     ok: true,
     config: http
-      ? { ...base, transport: 'http' as const, apiKey: apiKey?.trim() }
+      ? {
+          ...base,
+          transport: 'http' as const,
+          apiKey: apiKey?.trim(),
+          host: resolveHost(parsed, env),
+          allowedHosts: parseAllowedHosts(parsed, env),
+        }
       : { ...base, transport: 'stdio' as const, apiKey: apiKey!.trim() },
   };
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -21,6 +21,14 @@ export interface HttpConfig {
   replierEmailAddresses: string[];
   transport: 'http';
   port: number;
+  /**
+   * Host used for the SDK's DNS-rebinding protection. Undefined keeps the
+   * localhost-only default. Set to '0.0.0.0' to disable Host validation when
+   * running behind a proxy / load balancer (protected by per-request auth).
+   */
+  host?: string;
+  /** Explicit allow-list of acceptable Host header hostnames. */
+  allowedHosts?: string[];
 }
 
 export type CliConfig = StdioConfig | HttpConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ if (config.transport === 'http') {
   // HTTP mode: no Resend client needed at startup. Each connecting client
   // provides their own API key via the Authorization: Bearer header,
   // and a per-session Resend client is created in the transport layer.
-  runHttp(serverOptions, config.port).catch(onFatal);
+  runHttp(serverOptions, config.port, {
+    host: config.host,
+    allowedHosts: config.allowedHosts,
+  }).catch(onFatal);
 } else {
   // Stdio mode: single user, API key is required at startup.
   const resend = new Resend(config.apiKey);

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -36,6 +36,29 @@ function extractBearerToken(req: IncomingMessage): string | null {
   return token || null;
 }
 
+export interface HttpTransportOptions {
+  /**
+   * Host used to derive the SDK's DNS-rebinding protection. Defaults to
+   * `'127.0.0.1'`, which keeps localhost-only `Host` header validation enabled
+   * — the safe default for servers run locally.
+   *
+   * Set to `'0.0.0.0'` when deploying behind a reverse proxy / load balancer
+   * where the server is already protected by per-request auth (the Bearer API
+   * key). This disables `Host` validation so the proxy's forwarded `Host` and
+   * load-balancer health-check requests (which use the task's private IP) are
+   * accepted instead of rejected with `403 Invalid Host`.
+   */
+  host?: string;
+  /**
+   * Explicit allow-list of acceptable `Host` header hostnames. When provided,
+   * only these are accepted (overrides the `host`-based default). Use this to
+   * pin specific public hostnames instead of disabling validation entirely.
+   * Note: a load balancer health check sends the task IP as `Host`, so an
+   * allow-list must also include that if the LB health-checks this server.
+   */
+  allowedHosts?: string[];
+}
+
 /**
  * Start the HTTP transport. Each session gets its own Resend client created
  * from the Bearer token provided by the connecting client. This allows
@@ -45,8 +68,10 @@ function extractBearerToken(req: IncomingMessage): string | null {
 export async function runHttp(
   options: ServerOptions,
   port: number,
+  httpOptions: HttpTransportOptions = {},
 ): Promise<Server> {
-  const app = createMcpExpressApp();
+  const { host = '127.0.0.1', allowedHosts } = httpOptions;
+  const app = createMcpExpressApp({ host, allowedHosts });
 
   app.get('/health', (_req: IncomingMessage, res: ServerResponse) => {
     res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -76,7 +76,11 @@ describe('runHttp', () => {
     });
     const { port } = server.address() as AddressInfo;
 
-    const res = await getWithHost(port, '/health', 'remote-mcp.apps.example.com');
+    const res = await getWithHost(
+      port,
+      '/health',
+      'remote-mcp.apps.example.com',
+    );
     expect(res.status).toBe(200);
 
     server.close();

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -1,6 +1,30 @@
+import { request } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runHttp } from '../../src/transports/http.js';
+
+/**
+ * GET a path with an explicit Host header. Uses node:http because fetch/undici
+ * forbids overriding the Host header, which is exactly what we need to assert
+ * the DNS-rebinding (Host) validation behaviour.
+ */
+function getWithHost(
+  port: number,
+  path: string,
+  host: string,
+): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { host: '127.0.0.1', port, path, method: 'GET', headers: { host } },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve({ status: res.statusCode ?? 0 }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
 
 vi.mock('../../src/server.js', () => ({
   createMcpServer: vi.fn(() => ({
@@ -32,6 +56,43 @@ describe('runHttp', () => {
 
     expect(res.status).toBe(200);
     expect(body).toEqual({ status: 'ok' });
+
+    server.close();
+  });
+
+  it('rejects a non-localhost Host header by default (localhost protection on)', async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await getWithHost(port, '/health', 'evil.example.com');
+    expect(res.status).toBe(403);
+
+    server.close();
+  });
+
+  it("accepts any Host header when host is '0.0.0.0'", async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0, {
+      host: '0.0.0.0',
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const res = await getWithHost(port, '/health', 'remote-mcp.apps.example.com');
+    expect(res.status).toBe(200);
+
+    server.close();
+  });
+
+  it('accepts only hosts in the allowedHosts list', async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0, {
+      allowedHosts: ['mcp.example.com'],
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const allowed = await getWithHost(port, '/health', 'mcp.example.com');
+    expect(allowed.status).toBe(200);
+
+    const denied = await getWithHost(port, '/health', 'other.example.com');
+    expect(denied.status).toBe(403);
 
     server.close();
   });


### PR DESCRIPTION
## Problem

`runHttp()` calls `createMcpExpressApp()` with no options, so the MCP SDK applies **localhost-only** `Host` validation (`localhostHostValidation` → allows only `localhost`/`127.0.0.1`/`[::1]`). Behind a reverse proxy / load balancer this returns `403 Invalid Host` for:
- the public hostname, and
- the load-balancer health check (which sends the task's private IP as `Host`),

so a hosted deployment can never pass health checks or be reached at its public URL.

## Change

Add an optional third arg to `runHttp(options, port, httpOptions?)`:

```ts
runHttp({}, 3000, { host: '0.0.0.0' });                 // disable Host validation (behind a proxy/LB)
runHttp({}, 3000, { allowedHosts: ['mcp.example.com'] }); // or pin specific hostnames
```

Wired through the CLI too: `--host` / `--allowed-hosts` and `MCP_HOST` / `MCP_ALLOWED_HOSTS`.

## Backward compatibility (no break for local users)

The default `host` is `'127.0.0.1'`, so `runHttp(options, port)` and `resend-mcp --http` behave **exactly as before** — localhost-only DNS-rebinding protection stays on. Disabling it is strictly opt-in, and appropriate for hosted use since the server is already protected by the per-request `Authorization: Bearer` API key.

## Tests

- default rejects a non-localhost `Host` → `403` (protection preserved)
- `host: '0.0.0.0'` accepts any `Host` → `200`
- `allowedHosts` pins specific hostnames (allowed → 200, other → 403)

All 72 tests pass; build + lint clean (pre-existing lint findings untouched). Bumped to **2.6.3**.