### PR TITLE
feat: serve MCP transport at root / in addition to /mcp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -78,69 +78,74 @@ export async function runHttp(
     res.end(JSON.stringify({ status: 'ok' }));
   });
 
-  app.all(
-    '/mcp',
-    async (req: IncomingMessage & { body?: unknown }, res: ServerResponse) => {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      let transport: StreamableHTTPServerTransport | undefined;
+  // Serve the Streamable HTTP transport at both `/mcp` and the root `/` so
+  // clients and proxies that target the server's root URL work identically.
+  const handleMcp = async (
+    req: IncomingMessage & { body?: unknown },
+    res: ServerResponse,
+  ) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    let transport: StreamableHTTPServerTransport | undefined;
 
-      if (sessionId && sessions[sessionId]) {
-        transport = sessions[sessionId];
-      } else if (
-        !sessionId &&
-        req.method === 'POST' &&
-        isInitializeRequest(req.body)
-      ) {
-        // New session: require a Bearer token so we can create a per-session
-        // Resend client scoped to this user's API key.
-        const apiKey = extractBearerToken(req);
-        if (!apiKey) {
-          sendJsonRpcError(
-            res,
-            401,
-            'Unauthorized: provide a Resend API key via Authorization: Bearer <key>',
-          );
-          return;
-        }
-
-        const resend = new Resend(apiKey);
-
-        transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          onsessioninitialized: (sid) => {
-            sessions[sid] = transport!;
-          },
-        });
-        transport.onclose = () => {
-          const sid = transport!.sessionId;
-          if (sid && sessions[sid]) delete sessions[sid];
-        };
-        const server = createMcpServer(resend, options, apiKey);
-        await server.connect(transport);
-      } else if (sessionId && !sessions[sessionId]) {
-        res.statusCode = 404;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            error: { code: -32001, message: 'Session not found' },
-            id: null,
-          }),
+    if (sessionId && sessions[sessionId]) {
+      transport = sessions[sessionId];
+    } else if (
+      !sessionId &&
+      req.method === 'POST' &&
+      isInitializeRequest(req.body)
+    ) {
+      // New session: require a Bearer token so we can create a per-session
+      // Resend client scoped to this user's API key.
+      const apiKey = extractBearerToken(req);
+      if (!apiKey) {
+        sendJsonRpcError(
+          res,
+          401,
+          'Unauthorized: provide a Resend API key via Authorization: Bearer <key>',
         );
-        return;
-      } else {
-        sendJsonRpcError(res, 400, 'Bad Request: No valid session ID provided');
         return;
       }
 
-      await transport.handleRequest(req, res, req.body);
-    },
-  );
+      const resend = new Resend(apiKey);
+
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid) => {
+          sessions[sid] = transport!;
+        },
+      });
+      transport.onclose = () => {
+        const sid = transport!.sessionId;
+        if (sid && sessions[sid]) delete sessions[sid];
+      };
+      const server = createMcpServer(resend, options, apiKey);
+      await server.connect(transport);
+    } else if (sessionId && !sessions[sessionId]) {
+      res.statusCode = 404;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Session not found' },
+          id: null,
+        }),
+      );
+      return;
+    } else {
+      sendJsonRpcError(res, 400, 'Bad Request: No valid session ID provided');
+      return;
+    }
+
+    await transport.handleRequest(req, res, req.body);
+  };
+
+  app.all('/mcp', handleMcp);
+  app.all('/', handleMcp);
 
   return new Promise((resolve, reject) => {
     const server = app.listen(port, () => {
       console.error(`Resend MCP server listening on http://127.0.0.1:${port}`);
-      console.error('  Streamable HTTP: POST/GET/DELETE /mcp');
+      console.error('  Streamable HTTP: POST/GET/DELETE / and /mcp');
       resolve(server);
     });
     server.once('error', reject);

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -60,6 +60,54 @@ describe('runHttp', () => {
     server.close();
   });
 
+  it('POST / without a Bearer token returns 401 (routes to MCP transport)', async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0.0.0' },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+
+    server.close();
+  });
+
+  it('POST /mcp without a Bearer token returns 401', async () => {
+    const server = await runHttp({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0.0.0' },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+
+    server.close();
+  });
+
   it('rejects a non-localhost Host header by default (localhost protection on)', async () => {
     const server = await runHttp({ replierEmailAddresses: [] }, 0);
     const { port } = server.address() as AddressInfo;


### PR DESCRIPTION
## Summary

The HTTP transport previously exposed the Streamable HTTP MCP endpoint only at `/mcp`. Many MCP clients and proxies target the server's root URL `/`. This change makes `/` behave identically to `/mcp` — same session handling, Bearer-token auth, and transport — so the server works whether clients point at `https://host/` or `https://host/mcp`.

## Changes

- Extracted the inline `/mcp` handler into a named `handleMcp` function (logic unchanged) and registered it on both `app.all('/mcp', …)` and `app.all('/', …)` in `src/transports/http.ts`.
- Updated the startup log to advertise `POST/GET/DELETE / and /mcp`.
- `/health` is unaffected — Express's `app.all('/', …)` matches only the exact root path, so it does not shadow other routes.
- Bumped version `2.7.1` → `2.8.0`.

## Tests

- Added a test that `POST /` (initialize) without a Bearer token returns `401`, confirming `/` routes into the MCP transport.
- Added the parity test for `POST /mcp`.

## Verification

- `npm test` → 78 passed (incl. 2 new tests)
- `npm run build` → compiles clean
- `biome check` formatting applied