### PR TITLE
feat: add MCP tools for bulk CSV contact imports

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
   addApiKeyTools,
   addAutomationTools,
   addBroadcastTools,
+  addContactImportTools,
   addContactPropertyTools,
   addContactTools,
   addDomainTools,
@@ -45,6 +46,7 @@ export function createMcpServer(
     replierEmailAddresses,
     withEditorSession,
   });
+  addContactImportTools(server, resend);
   addContactPropertyTools(server, resend);
   addContactTools(server, resend);
   addDomainTools(server, resend);

--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -1,0 +1,310 @@
+import { readFile } from 'node:fs/promises';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { z } from 'zod';
+
+export function addContactImportTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'create-contact-import',
+    {
+      title: 'Create Contact Import',
+      description:
+        'Bulk-import contacts from a CSV file into Resend. The import is processed asynchronously: this returns an import ID immediately, then use get-contact-import to poll its status and counts. Provide the CSV via exactly one of `filePath`, `content`, or `url`. Max file size 100MB.',
+      inputSchema: {
+        filePath: z
+          .string()
+          .optional()
+          .describe(
+            'Local path to a CSV file to read and upload. Use one of filePath, content, or url.',
+          ),
+        content: z
+          .string()
+          .optional()
+          .describe(
+            'Raw CSV text to upload (e.g. "email,first_name\\na@b.com,Ada"). Use one of filePath, content, or url.',
+          ),
+        url: z
+          .string()
+          .optional()
+          .describe(
+            'URL of a CSV file to fetch and upload. Use one of filePath, content, or url.',
+          ),
+        filename: z
+          .string()
+          .optional()
+          .describe('Name for the uploaded file. Defaults to "contacts.csv".'),
+        columnMap: z
+          .object({
+            email: z
+              .string()
+              .optional()
+              .describe('CSV header name that contains email addresses.'),
+            firstName: z
+              .string()
+              .optional()
+              .describe('CSV header name that contains first names.'),
+            lastName: z
+              .string()
+              .optional()
+              .describe('CSV header name that contains last names.'),
+            unsubscribed: z
+              .string()
+              .optional()
+              .describe('CSV header name that contains the unsubscribed flag.'),
+            properties: z
+              .record(
+                z.string(),
+                z.object({
+                  column: z
+                    .string()
+                    .describe('CSV header name to map to this property.'),
+                  type: z
+                    .enum(['string', 'number', 'boolean'])
+                    .optional()
+                    .describe('Property type. Defaults to "string".'),
+                }),
+              )
+              .optional()
+              .describe(
+                'Maps custom property keys to CSV columns (e.g. { "company_name": { "column": "Company" } }).',
+              ),
+          })
+          .optional()
+          .describe(
+            'Maps contact fields to CSV header names. When omitted, headers are matched case-sensitively to "email", "first_name", and "last_name".',
+          ),
+        onConflict: z
+          .enum(['upsert', 'skip'])
+          .optional()
+          .describe(
+            'How to handle contacts that already exist: "upsert" updates them, "skip" leaves them unchanged. Defaults to "upsert".',
+          ),
+        segmentIds: z
+          .array(z.string())
+          .optional()
+          .describe('Array of segment IDs to assign the imported contacts to.'),
+        topics: z
+          .array(
+            z.object({
+              id: z.string().describe('Topic ID'),
+              subscription: z
+                .enum(['opt_in', 'opt_out'])
+                .describe('Subscription preference for this topic'),
+            }),
+          )
+          .optional()
+          .describe(
+            'Topic subscription configurations applied to the imported contacts.',
+          ),
+      },
+    },
+    async ({
+      filePath,
+      content,
+      url,
+      filename,
+      columnMap,
+      onConflict,
+      segmentIds,
+      topics,
+    }) => {
+      const sources = [filePath, content, url].filter(
+        (s) => s !== undefined,
+      ).length;
+      if (sources !== 1) {
+        throw new Error(
+          'Provide exactly one of "filePath", "content", or "url" for the CSV file.',
+        );
+      }
+
+      let fileData: BlobPart;
+      if (filePath !== undefined) {
+        fileData = await readFile(filePath);
+      } else if (url !== undefined) {
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch CSV from url (${res.status} ${res.statusText}).`,
+          );
+        }
+        fileData = await res.arrayBuffer();
+      } else {
+        fileData = content as string;
+      }
+
+      const file = new File([fileData], filename ?? 'contacts.csv', {
+        type: 'text/csv',
+      });
+
+      const response = await resend.contacts.imports.create({
+        file,
+        columnMap,
+        onConflict,
+        segments: segmentIds?.map((id) => ({ id })),
+        topics,
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to create contact import: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const created = response.data;
+      return {
+        content: [
+          { type: 'text', text: 'Contact import created successfully.' },
+          { type: 'text', text: `Import ID: ${created.id}` },
+          {
+            type: 'text',
+            text: 'The import runs asynchronously. Use get-contact-import with this ID to check its status and counts.',
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'get-contact-import',
+    {
+      title: 'Get Contact Import',
+      description:
+        'Get the status and counts of a contact import by ID. Use after create-contact-import to track progress (queued, in_progress, completed, failed).',
+      inputSchema: {
+        id: z.string().describe('Contact import ID'),
+      },
+    },
+    async ({ id }) => {
+      const response = await resend.contacts.imports.get(id);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to get contact import: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const item = response.data;
+      const counts = item.counts;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              `ID: ${item.id}`,
+              `Status: ${item.status}`,
+              `Total: ${counts.total}`,
+              `Created: ${counts.created}`,
+              `Updated: ${counts.updated}`,
+              `Skipped: ${counts.skipped}`,
+              `Failed: ${counts.failed}`,
+              `Created at: ${item.created_at}`,
+              item.completed_at != null && `Completed at: ${item.completed_at}`,
+            ]
+              .filter(Boolean)
+              .join('\n'),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'list-contact-imports',
+    {
+      title: 'List Contact Imports',
+      description:
+        'List contact imports from Resend. Optionally filter by status. Use to discover import IDs or review past imports.',
+      inputSchema: {
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe(
+            'Number of contact imports to retrieve. Default: 10, Max: 100, Min: 1',
+          ),
+        after: z
+          .string()
+          .optional()
+          .describe(
+            'Contact import ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+          ),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            'Contact import ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+          ),
+        status: z
+          .enum(['queued', 'in_progress', 'completed', 'failed'])
+          .optional()
+          .describe('Filter imports by status.'),
+      },
+    },
+    async ({ limit, after, before, status }) => {
+      if (after && before) {
+        throw new Error(
+          'Cannot use both "after" and "before" parameters. Use only one for pagination.',
+        );
+      }
+
+      const options: Record<string, unknown> = {};
+      if (limit !== undefined) options.limit = limit;
+      if (after) options.after = after;
+      if (before) options.before = before;
+      if (status) options.status = status;
+
+      const response = await resend.contacts.imports.list(
+        Object.keys(options).length > 0 ? options : undefined,
+      );
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list contact imports: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const imports = response.data?.data ?? [];
+      const hasMore = response.data?.has_more ?? false;
+
+      if (imports.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No contact imports found.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${imports.length} contact import${imports.length === 1 ? '' : 's'}:`,
+          },
+          ...imports.map((item) => ({
+            type: 'text' as const,
+            text: [
+              `ID: ${item.id}`,
+              `Status: ${item.status}`,
+              `Total: ${item.counts.total}`,
+              `Created: ${item.counts.created}`,
+              `Updated: ${item.counts.updated}`,
+              `Skipped: ${item.counts.skipped}`,
+              `Failed: ${item.counts.failed}`,
+              `Created at: ${item.created_at}`,
+              item.completed_at != null && `Completed at: ${item.completed_at}`,
+            ]
+              .filter(Boolean)
+              .join('\n'),
+          })),
+          ...(hasMore
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more contact imports available. Use the "after" parameter with the last ID to retrieve more.',
+                },
+              ]
+            : []),
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 export * from './apiKeys.js';
 export * from './automations.js';
 export * from './broadcasts.js';
+export * from './contactImports.js';
 export * from './contactProperties.js';
 export * from './contacts.js';
 export * from './domains.js';

--- a/tests/tools/contactImports.test.ts
+++ b/tests/tools/contactImports.test.ts
@@ -1,0 +1,234 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addContactImportTools } from '../../src/tools/contactImports.js';
+
+const create = vi.fn();
+const get = vi.fn();
+const list = vi.fn();
+
+const resend = {
+  contacts: { imports: { create, get, list } },
+} as unknown as Resend;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addContactImportTools(server, resend);
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+describe('create-contact-import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    create.mockResolvedValue({
+      data: { object: 'contact_import', id: 'imp_1' },
+    });
+  });
+
+  it('registers the three import tools', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('create-contact-import');
+    expect(names).toContain('get-contact-import');
+    expect(names).toContain('list-contact-imports');
+  });
+
+  it('uploads raw CSV content and returns the import ID', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'create-contact-import',
+      arguments: { content: 'email,first_name\na@b.com,Ada' },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const payload = create.mock.calls[0][0];
+    expect(payload.file).toBeInstanceOf(Blob);
+    expect(payload.file.name).toBe('contacts.csv');
+    expect(await payload.file.text()).toBe('email,first_name\na@b.com,Ada');
+    expect(textOf(result as never)).toContain('Import ID: imp_1');
+  });
+
+  it('maps segmentIds to segment objects and passes through columnMap/onConflict/topics', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'create-contact-import',
+      arguments: {
+        content: 'a,b',
+        columnMap: { email: 'Email Address' },
+        onConflict: 'skip',
+        segmentIds: ['seg_1', 'seg_2'],
+        topics: [{ id: 'top_1', subscription: 'opt_in' }],
+      },
+    });
+
+    const payload = create.mock.calls[0][0];
+    expect(payload.columnMap).toEqual({ email: 'Email Address' });
+    expect(payload.onConflict).toBe('skip');
+    expect(payload.segments).toEqual([{ id: 'seg_1' }, { id: 'seg_2' }]);
+    expect(payload.topics).toEqual([{ id: 'top_1', subscription: 'opt_in' }]);
+  });
+
+  it('honors a custom filename', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'create-contact-import',
+      arguments: { content: 'a,b', filename: 'people.csv' },
+    });
+    expect(create.mock.calls[0][0].file.name).toBe('people.csv');
+  });
+
+  it('errors when no file source is provided', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'create-contact-import',
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('exactly one of');
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('errors when multiple file sources are provided', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'create-contact-import',
+      arguments: { content: 'a,b', url: 'https://example.com/c.csv' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('exactly one of');
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('surfaces SDK errors', async () => {
+    create.mockResolvedValueOnce({ error: { message: 'bad csv' } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'create-contact-import',
+      arguments: { content: 'a,b' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      'Failed to create contact import',
+    );
+  });
+});
+
+describe('get-contact-import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('formats status and counts', async () => {
+    get.mockResolvedValue({
+      data: {
+        object: 'contact_import',
+        id: 'imp_1',
+        status: 'completed',
+        created_at: '2026-01-01T00:00:00Z',
+        completed_at: '2026-01-01T00:01:00Z',
+        counts: { total: 5, created: 3, updated: 1, skipped: 1, failed: 0 },
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'get-contact-import',
+      arguments: { id: 'imp_1' },
+    });
+    expect(get).toHaveBeenCalledWith('imp_1');
+    const text = textOf(result as never);
+    expect(text).toContain('Status: completed');
+    expect(text).toContain('Created: 3');
+    expect(text).toContain('Completed at: 2026-01-01T00:01:00Z');
+  });
+
+  it('omits completed_at when null', async () => {
+    get.mockResolvedValue({
+      data: {
+        object: 'contact_import',
+        id: 'imp_1',
+        status: 'in_progress',
+        created_at: '2026-01-01T00:00:00Z',
+        completed_at: null,
+        counts: { total: 0, created: 0, updated: 0, skipped: 0, failed: 0 },
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'get-contact-import',
+      arguments: { id: 'imp_1' },
+    });
+    expect(textOf(result as never)).not.toContain('Completed at');
+  });
+});
+
+describe('list-contact-imports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes status and limit, and shows a has_more hint', async () => {
+    list.mockResolvedValue({
+      data: {
+        has_more: true,
+        data: [
+          {
+            object: 'contact_import',
+            id: 'imp_1',
+            status: 'completed',
+            created_at: '2026-01-01T00:00:00Z',
+            completed_at: '2026-01-01T00:01:00Z',
+            counts: { total: 1, created: 1, updated: 0, skipped: 0, failed: 0 },
+          },
+        ],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-contact-imports',
+      arguments: { status: 'completed', limit: 5 },
+    });
+    expect(list).toHaveBeenCalledWith({ limit: 5, status: 'completed' });
+    const text = textOf(result as never);
+    expect(text).toContain('Found 1 contact import:');
+    expect(text).toContain('There are more contact imports available');
+  });
+
+  it('reports when none are found', async () => {
+    list.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-contact-imports',
+      arguments: {},
+    });
+    expect(list).toHaveBeenCalledWith(undefined);
+    expect(textOf(result as never)).toContain('No contact imports found.');
+  });
+
+  it('rejects using both after and before', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-contact-imports',
+      arguments: { after: 'a', before: 'b' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Cannot use both');
+    expect(list).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
You can see it working here:

https://www.loom.com/share/279dfe2baad94a9c92e4a28053caec78

## Summary
- Adds three MCP tools for Resend's contact import API: `create-contact-import`, `get-contact-import`, and `list-contact-imports`
- Supports CSV upload via local file path, raw content, or URL, with optional column mapping, conflict handling, segment assignment, and topic subscriptions
- Includes unit tests covering tool registration, upload payloads, pagination, and error cases

## Test plan
- [x] `pnpm test` passes (90 tests)
- [ ] Start local MCP server and verify tools appear in Cursor after OAuth connect
- [ ] Call `create-contact-import` with sample CSV content and confirm import ID is returned
- [ ] Poll `get-contact-import` until status is `completed` and verify counts
- [ ] Call `list-contact-imports` and confirm the new import appears


Made with [Cursor](https://cursor.com)