### PR TITLE
feat: add list and revoke OAuth grant tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.14.0",
+    "resend": "6.17.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.17.0",
+    "resend": "6.17.1",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.14.0
-        version: 6.14.0
+        specifier: 6.17.0
+        version: 6.17.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -815,8 +815,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.14.0:
-    resolution: {integrity: sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==}
+  resend@6.17.0:
+    resolution: {integrity: sha512-hYNLU58nKg1Sx9kPF1E6fo447/9OMNbk3pOzuQGZMtoRU4FhtNTrW7SHFLPT8F8quTcIAa6Cs5Q5hEuWHJNTpA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1654,7 +1654,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resend@6.14.0:
+  resend@6.17.0:
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.17.0
-        version: 6.17.0
+        specifier: 6.17.1
+        version: 6.17.1
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -815,8 +815,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.17.0:
-    resolution: {integrity: sha512-hYNLU58nKg1Sx9kPF1E6fo447/9OMNbk3pOzuQGZMtoRU4FhtNTrW7SHFLPT8F8quTcIAa6Cs5Q5hEuWHJNTpA==}
+  resend@6.17.1:
+    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1654,7 +1654,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resend@6.17.0:
+  resend@6.17.1:
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
-  - resend@6.14.0
   - resend@6.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
-  - resend@6.17.0
+  - resend@6.17.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
   - resend@6.14.0
+  - resend@6.17.0

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import {
   addEmailTools,
   addEventTools,
   addLogTools,
+  addOAuthGrantTools,
   addSegmentTools,
   addTemplateTools,
   addTopicTools,
@@ -53,6 +54,7 @@ export function createMcpServer(
   addEmailTools(server, resend, { senderEmailAddress, replierEmailAddresses });
   addEventTools(server, resend);
   addLogTools(server, resend);
+  addOAuthGrantTools(server, resend);
   addSegmentTools(server, resend);
   addTemplateTools(server, resend, apiClient, { withEditorSession });
   addTopicTools(server, resend);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ export * from './editor.js';
 export * from './emails.js';
 export * from './events.js';
 export * from './logs.js';
+export * from './oauthGrants.js';
 export * from './segments.js';
 export * from './templates.js';
 export * from './topics.js';

--- a/src/tools/oauthGrants.ts
+++ b/src/tools/oauthGrants.ts
@@ -1,0 +1,121 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { z } from 'zod';
+
+export function addOAuthGrantTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'list-oauth-grants',
+    {
+      title: 'List OAuth Grants',
+      description:
+        "List OAuth grants for the team — the apps authorized to act on the team's behalf. Returns every grant, active and revoked; a grant with a non-null revoked_at is no longer active. Each grant includes the client (app) name, scopes, and creation date. Don't bother telling the user the IDs unless they ask for them.",
+      inputSchema: {
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Number of OAuth grants to retrieve. Max: 100, Min: 1'),
+        after: z
+          .string()
+          .optional()
+          .describe(
+            'OAuth grant ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+          ),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            'OAuth grant ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+          ),
+      },
+    },
+    async ({ limit, after, before }) => {
+      if (after !== undefined && before !== undefined) {
+        throw new Error(
+          'Cannot use both "after" and "before" parameters. Use only one for pagination.',
+        );
+      }
+
+      if (after === '' || before === '') {
+        throw new Error(
+          '"after" and "before" must be non-empty when provided.',
+        );
+      }
+
+      const paginationOptions =
+        after !== undefined
+          ? { limit, after }
+          : before !== undefined
+            ? { limit, before }
+            : limit !== undefined
+              ? { limit }
+              : undefined;
+
+      const response = await resend.oauthGrants.list(paginationOptions);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list OAuth grants: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const grants = response.data?.data ?? [];
+      const hasMore = response.data?.has_more ?? false;
+
+      if (grants.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No OAuth grants found.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${grants.length} OAuth grant${grants.length === 1 ? '' : 's'}:`,
+          },
+          ...grants.map((grant) => ({
+            type: 'text' as const,
+            text: `App: ${grant.client.name}\nID: ${grant.id}\nScopes: ${grant.scopes.join(', ')}\nCreated at: ${grant.created_at}\nStatus: ${
+              grant.revoked_at ? `revoked (${grant.revoked_at})` : 'active'
+            }`,
+          })),
+          ...(hasMore
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more OAuth grants available. Use the "after" parameter with the last ID to retrieve more.',
+                },
+              ]
+            : []),
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'revoke-oauth-grant',
+    {
+      title: 'Revoke OAuth Grant',
+      description:
+        'Revoke an OAuth grant by ID. Before using this tool, you MUST double-check with the user that they want to revoke this grant. Reference the NAME of the app (client) when double-checking, and warn the user that revocation is immediate and irreversible — every access and refresh token issued under the grant stops working, and the app would need to be re-authorized to regain access. You may only use this tool if the user explicitly confirms they want to revoke the grant after you double-check.',
+      inputSchema: {
+        id: z.string().nonempty().describe('OAuth grant ID'),
+      },
+    },
+    async ({ id }) => {
+      const response = await resend.oauthGrants.revoke(id);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to revoke OAuth grant: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [{ type: 'text', text: 'OAuth grant revoked successfully.' }],
+      };
+    },
+  );
+}

--- a/tests/tools/oauthGrants.test.ts
+++ b/tests/tools/oauthGrants.test.ts
@@ -1,0 +1,187 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addOAuthGrantTools } from '../../src/tools/oauthGrants.js';
+
+const list = vi.fn();
+const revoke = vi.fn();
+
+const resend = {
+  oauthGrants: { list, revoke },
+} as unknown as Resend;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addOAuthGrantTools(server, resend);
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+const grant = {
+  id: 'grant_1',
+  client_id: 'client_1',
+  scopes: ['emails:send'],
+  resource: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  revoked_at: null,
+  revoked_reason: null,
+  client: { name: 'Resend CLI', logo_uri: null },
+};
+
+describe('oauth grant tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers both tools', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('list-oauth-grants');
+    expect(names).toContain('revoke-oauth-grant');
+  });
+});
+
+describe('list-oauth-grants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    list.mockResolvedValue({
+      data: {
+        object: 'list',
+        has_more: false,
+        data: [
+          grant,
+          {
+            ...grant,
+            id: 'grant_2',
+            scopes: ['emails:send', 'domains:read'],
+            revoked_at: '2026-01-02T00:00:00.000Z',
+            revoked_reason: 'revoked_from_api',
+          },
+        ],
+      },
+      error: null,
+    });
+  });
+
+  it('lists grants with client, scopes, and status', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: {},
+    });
+
+    expect(list).toHaveBeenCalledTimes(1);
+    const text = textOf(result as never);
+    expect(text).toContain('Found 2 OAuth grants');
+    expect(text).toContain('App: Resend CLI');
+    expect(text).toContain('emails:send, domains:read');
+    expect(text).toContain('active');
+    expect(text).toContain('revoked (2026-01-02T00:00:00.000Z)');
+  });
+
+  it('forwards the limit to the SDK', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: { limit: 25 },
+    });
+    expect(list).toHaveBeenCalledWith({ limit: 25 });
+  });
+
+  it('errors when both after and before are provided', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: { after: 'a', before: 'b' },
+    });
+    expect(result.isError).toBe(true);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('errors when a cursor is an empty string', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: { after: '' },
+    });
+    expect(result.isError).toBe(true);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('reports when there are no grants', async () => {
+    list.mockResolvedValueOnce({
+      data: { object: 'list', has_more: false, data: [] },
+      error: null,
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: {},
+    });
+    expect(textOf(result as never)).toContain('No OAuth grants found.');
+  });
+
+  it('surfaces SDK errors', async () => {
+    list.mockResolvedValueOnce({ error: { message: 'nope' } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-oauth-grants',
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Failed to list OAuth grants');
+  });
+});
+
+describe('revoke-oauth-grant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    revoke.mockResolvedValue({
+      data: {
+        object: 'oauth_grant',
+        id: 'grant_1',
+        revoked_at: '2026-01-02T00:00:00.000Z',
+        revoked_reason: 'revoked_from_api',
+      },
+      error: null,
+    });
+  });
+
+  it('revokes a grant by id', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'revoke-oauth-grant',
+      arguments: { id: 'grant_1' },
+    });
+
+    expect(revoke).toHaveBeenCalledWith('grant_1');
+    expect(textOf(result as never)).toContain('OAuth grant revoked');
+  });
+
+  it('surfaces SDK errors', async () => {
+    revoke.mockResolvedValueOnce({ error: { message: 'not found' } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'revoke-oauth-grant',
+      arguments: { id: 'grant_1' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Failed to revoke OAuth grant');
+  });
+});

--- a/tests/tools/oauthGrants.test.ts
+++ b/tests/tools/oauthGrants.test.ts
@@ -36,7 +36,6 @@ const grant = {
   id: 'grant_1',
   client_id: 'client_1',
   scopes: ['emails:send'],
-  resource: null,
   created_at: '2026-01-01T00:00:00.000Z',
   revoked_at: null,
   revoked_reason: null,


### PR DESCRIPTION
## What

Adds OAuth grant management tools to the MCP server, mirroring the existing `api-keys` tool pattern:

- **`list-oauth-grants`** — lists all of the team's grants (active and revoked) with the app (client) name, scopes, created date, and status. Supports `limit` / `after` / `before` pagination.
- **`revoke-oauth-grant`** — the description instructs the model to double-check with the user **by app name** and warn that revocation is immediate and irreversible before calling.

## Changes

- `src/tools/oauthGrants.ts` — the two tools
- `src/tools/index.ts`, `src/server.ts` — export + register
- `tests/tools/oauthGrants.test.ts` — 9 tests (registration, list shape, pagination guards incl. empty-string cursor, empty result, SDK errors, revoke)
- `package.json` + lockfile — bump `resend` `6.14.0 → 6.17.0` for oauthGrants SDK support

Cursor validation uses explicit `undefined` checks and rejects empty-string cursors so LLM-supplied empty values fail fast rather than being silently ignored.

## Testing

- `tsc --noEmit` ✓, biome ✓
- tests 9/9 ✓ (run via `./node_modules/.bin/vitest` — see note below)

## Note — release-age gate

`resend@6.17.0` was published very recently, so pnpm's `minimumReleaseAge` supply-chain gate currently rejects it (the existing `minimumReleaseAgeExclude` entries are version-pinned, which pnpm matches by name pattern, so they don't exempt it). `pnpm install` / CI will stay red until the version ages past the cutoff (or the exclude is switched to a name-only `resend` entry — a maintainer policy call). Local verification was done by running the compiler and vitest directly against the installed `resend@6.17.0`.

## Related

- Public API: resend/resend-monorepo#5275 (list), #5260 (revoke, merged)
- OpenAPI: resend/resend-openapi#70 · Docs: resend/resend-docs#1618 · CLI: resend/resend-cli#340 · Remote MCP: resend/resend-monorepo#5347 · Node SDK: resend/resend-node#998 (v6.17.0)
