### PR TITLE
fix: accept display-name From on send-email

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -126,10 +126,10 @@ export function addEmailTools(
         ...(!senderEmailAddress
           ? {
               from: z
-                .email()
+                .string()
                 .nonempty()
                 .describe(
-                  'Sender email address. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+                  'Sender email address (e.g. "onboarding@resend.com" or "Acme <onboarding@resend.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
                 ),
             }
           : {}),

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -1,0 +1,86 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addEmailTools } from '../../src/tools/emails.js';
+
+const send = vi.fn();
+
+const resend = {
+  emails: { send },
+} as unknown as Resend;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addEmailTools(server, resend, {
+    replierEmailAddresses: [],
+  });
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+describe('send-email from address format', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    send.mockResolvedValue({
+      data: { id: 'email_1' },
+      error: null,
+    });
+  });
+
+  it('accepts bare email addresses in from', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'onboarding@resend.dev',
+        to: ['delivered@resend.dev'],
+        subject: 'hello',
+        text: 'world',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'onboarding@resend.dev',
+      }),
+    );
+    expect(textOf(result)).toContain('Email sent successfully');
+  });
+
+  it('accepts RFC 5322 display-name from addresses', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'Acme <onboarding@resend.dev>',
+        to: ['delivered@resend.dev'],
+        subject: 'hello',
+        text: 'world',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'Acme <onboarding@resend.dev>',
+      }),
+    );
+    expect(textOf(result)).toContain('Email sent successfully');
+  });
+});


### PR DESCRIPTION
## Summary
- `send-email` rejected RFC-5322 `Display Name <email>` because `from` used `z.email()`.
- #162 fixed only `send-batch-emails`, so #161 was closed while `send-email` stayed broken.
- Align `send-email` `from` with broadcasts/batch (`z.string().nonempty()`) and document both forms.

## Why this was not fixed before
Issue #161 reported that `send-email` rejected display-name From addresses. PR #162 was merged and titled as a send-email From fix, but the diff only changed the batch tool's `from` validator from `z.email()` to `z.string()`. #161 was then closed as fixed in 2.6.1, and the fuller #134 was closed as a duplicate of #162. What remained: the primary `send-email` tool still used `z.email()` on `from` through 2.10.0.

## Test plan

I verified the display-name case myself: `send-email` with `from: "Acme <onboarding@resend.dev>"` is accepted by the MCP tool schema and reaches `resend.emails.send` (no MCP `-32602` / invalid arguments). Covered by `tests/tools/emails.test.ts`.

### Reproduce locally

```bash
pnpm install
pnpm test tests/tools/emails.test.ts
pnpm test
pnpm build
```

### What the focused test covers

```bash
pnpm test tests/tools/emails.test.ts
```

- bare `from: "onboarding@resend.dev"` succeeds
- display-name `from: "Acme <onboarding@resend.dev>"` succeeds (the #161 regression)
- both calls assert `resend.emails.send` received the same `from` string

### Optional: confirm against main without this patch

On `main`, the same display-name `from` fails Zod/`z.email()` validation before the SDK is called. On this branch, the focused test above passes.
