### PR TITLE
feat: add idempotencyKey to send-email and send-batch-emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -122,6 +122,13 @@ export function addEmailTools(
           .describe(
             'Topic ID for subscription-based sending. When set, the email respects contact subscription preferences for this topic.',
           ),
+        idempotencyKey: z
+          .string()
+          .max(256)
+          .optional()
+          .describe(
+            'Optional unique key that prevents duplicate sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same logical email; use a new key for a different email. Max 256 characters.',
+          ),
         // If sender email address is not provided, the tool requires it as an argument
         ...(!senderEmailAddress
           ? {
@@ -158,6 +165,7 @@ export function addEmailTools(
       attachments,
       tags,
       topicId,
+      idempotencyKey,
     }) => {
       const fromEmailAddress = from ?? senderEmailAddress;
       const replyToEmailAddresses = replyTo ?? replierEmailAddresses;
@@ -265,7 +273,10 @@ export function addEmailTools(
         emailRequest.topicId = topicId;
       }
 
-      const response = await resend.emails.send(emailRequest);
+      const response = await resend.emails.send(
+        emailRequest,
+        idempotencyKey ? { idempotencyKey } : undefined,
+      );
 
       if (response.error) {
         throw new Error(
@@ -1014,9 +1025,16 @@ export function addEmailTools(
           .min(1)
           .max(100)
           .describe('Array of email objects to send (1-100 emails)'),
+        idempotencyKey: z
+          .string()
+          .max(256)
+          .optional()
+          .describe(
+            'Optional unique key for the whole batch that prevents duplicate batch sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same batch; use a new key for a different batch. Max 256 characters.',
+          ),
       },
     },
-    async ({ emails }) => {
+    async ({ emails, idempotencyKey }) => {
       const emailRequests = emails.map((email) => {
         const fromAddress = email.from ?? senderEmailAddress;
         const replyToAddresses = email.replyTo ?? replierEmailAddresses;
@@ -1047,6 +1065,7 @@ export function addEmailTools(
 
       const response = await resend.batch.send(
         emailRequests as unknown as Parameters<typeof resend.batch.send>[0],
+        idempotencyKey ? { idempotencyKey } : undefined,
       );
 
       if (response.error) {

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -170,10 +170,9 @@ describe('send-batch-emails idempotency key', () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(batchSend).toHaveBeenCalledWith(
-      expect.any(Array),
-      { idempotencyKey: 'team-quota/123456789' },
-    );
+    expect(batchSend).toHaveBeenCalledWith(expect.any(Array), {
+      idempotencyKey: 'team-quota/123456789',
+    });
     expect(textOf(result)).toContain('Batch sent successfully');
   });
 

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -6,9 +6,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addEmailTools } from '../../src/tools/emails.js';
 
 const send = vi.fn();
+const batchSend = vi.fn();
 
 const resend = {
   emails: { send },
+  batch: { send: batchSend },
 } as unknown as Resend;
 
 async function makeClient() {
@@ -59,6 +61,7 @@ describe('send-email from address format', () => {
       expect.objectContaining({
         from: 'onboarding@resend.dev',
       }),
+      undefined,
     );
     expect(textOf(result)).toContain('Email sent successfully');
   });
@@ -80,7 +83,116 @@ describe('send-email from address format', () => {
       expect.objectContaining({
         from: 'Acme <onboarding@resend.dev>',
       }),
+      undefined,
     );
     expect(textOf(result)).toContain('Email sent successfully');
+  });
+});
+
+describe('send-email idempotency key', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    send.mockResolvedValue({
+      data: { id: 'email_1' },
+      error: null,
+    });
+  });
+
+  it('passes idempotencyKey as the SDK options argument', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'Acme <onboarding@resend.dev>',
+        to: ['delivered@resend.dev'],
+        subject: 'hello',
+        text: 'world',
+        idempotencyKey: 'welcome-user/123456789',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'Acme <onboarding@resend.dev>',
+        to: ['delivered@resend.dev'],
+      }),
+      { idempotencyKey: 'welcome-user/123456789' },
+    );
+  });
+
+  it('omits SDK options when idempotencyKey is not provided', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'onboarding@resend.dev',
+        to: ['delivered@resend.dev'],
+        subject: 'hello',
+        text: 'world',
+      },
+    });
+
+    expect(send).toHaveBeenCalledWith(expect.any(Object), undefined);
+  });
+});
+
+describe('send-batch-emails idempotency key', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    batchSend.mockResolvedValue({
+      data: { data: [{ id: 'email_1' }, { id: 'email_2' }] },
+      error: null,
+    });
+  });
+
+  it('passes idempotencyKey as the SDK options argument', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-batch-emails',
+      arguments: {
+        emails: [
+          {
+            from: 'Acme <onboarding@resend.dev>',
+            to: ['foo@example.com'],
+            subject: 'hello',
+            text: 'one',
+          },
+          {
+            from: 'Acme <onboarding@resend.dev>',
+            to: ['bar@example.com'],
+            subject: 'hello',
+            text: 'two',
+          },
+        ],
+        idempotencyKey: 'team-quota/123456789',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(batchSend).toHaveBeenCalledWith(
+      expect.any(Array),
+      { idempotencyKey: 'team-quota/123456789' },
+    );
+    expect(textOf(result)).toContain('Batch sent successfully');
+  });
+
+  it('omits SDK options when idempotencyKey is not provided', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'send-batch-emails',
+      arguments: {
+        emails: [
+          {
+            from: 'onboarding@resend.dev',
+            to: ['foo@example.com'],
+            subject: 'hello',
+            text: 'one',
+          },
+        ],
+      },
+    });
+
+    expect(batchSend).toHaveBeenCalledWith(expect.any(Array), undefined);
   });
 });


### PR DESCRIPTION
## Summary
- Resend already supports an `Idempotency-Key` so retries do not send the same email twice.
- `send-email` and `send-batch-emails` did not expose that option, so agents could duplicate sends on timeout or "try again".
- Add optional `idempotencyKey` to both tools and pass it as the Resend SDK options argument.

## Why this matters
If an agent calls `send-email`, the request times out, and the agent retries with the same content, Resend may deliver two emails. With the same `idempotencyKey`, Resend treats the retry as the same operation instead of a second send.

This matches Resend's documented Node SDK usage:

```ts
await resend.emails.send(payload, { idempotencyKey: 'welcome-user/123' });
await resend.batch.send(payloads, { idempotencyKey: 'team-quota/123' });
```

## What changed
- `send-email`: optional `idempotencyKey` (max 256 chars)
- `send-batch-emails`: optional `idempotencyKey` for the whole batch (max 256 chars)
- When omitted, behavior is unchanged (SDK options stay `undefined`)

## Test plan

I verified this myself with MCP tool calls in `tests/tools/emails.test.ts`:
- `send-email` with `idempotencyKey: "welcome-user/123456789"` calls `resend.emails.send(payload, { idempotencyKey })`
- `send-email` without the key calls `resend.emails.send(payload, undefined)`
- `send-batch-emails` with `idempotencyKey: "team-quota/123456789"` calls `resend.batch.send(payloads, { idempotencyKey })`
- `send-batch-emails` without the key calls `resend.batch.send(payloads, undefined)`

### Reproduce locally

```bash
pnpm install
pnpm test tests/tools/emails.test.ts
pnpm test
pnpm build
```

### What the focused test covers

```bash
pnpm test tests/tools/emails.test.ts
```

- existing From display-name cases still pass
- send-email forwards `idempotencyKey` as the second SDK argument
- send-batch-emails forwards `idempotencyKey` as the second SDK argument
- omitting the key keeps the second argument `undefined`
