### PR TITLE
fix: accept display-name reply-to addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -149,10 +149,10 @@ export function addEmailTools(
         ...(replierEmailAddresses.length === 0
           ? {
               replyTo: z
-                .array(z.email())
+                .array(z.string())
                 .optional()
                 .describe(
-                  'Optional email addresses for the email readers to reply to. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+                  'Optional email addresses for the email readers to reply to (e.g. "support@example.com" or "Support Team <support@example.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
                 ),
             }
           : {}),
@@ -1005,9 +1005,11 @@ export function addEmailTools(
                   'Sender email address. Falls back to the configured default sender if not provided.',
                 ),
               replyTo: z
-                .array(z.email())
+                .array(z.string())
                 .optional()
-                .describe('Reply-to email addresses'),
+                .describe(
+                  'Reply-to email addresses (e.g. "support@example.com" or "Support Team <support@example.com>")',
+                ),
               cc: z.array(z.email()).optional().describe('CC email addresses'),
               bcc: z
                 .array(z.email())

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -89,6 +89,70 @@ describe('send-email from address format', () => {
   });
 });
 
+describe('replyTo address format', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    send.mockResolvedValue({
+      data: { id: 'email_1' },
+      error: null,
+    });
+    batchSend.mockResolvedValue({
+      data: { data: [{ id: 'email_1' }] },
+      error: null,
+    });
+  });
+
+  it.each([
+    'support@example.com',
+    'Support Team <support@example.com>',
+  ])('passes replyTo through send-email: %s', async (replyTo) => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'onboarding@resend.dev',
+        to: ['delivered@resend.dev'],
+        replyTo: [replyTo],
+        subject: 'hello',
+        text: 'world',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ replyTo: [replyTo] }),
+      undefined,
+    );
+  });
+
+  it.each([
+    'support@example.com',
+    'Support Team <support@example.com>',
+  ])('passes replyTo through send-batch-emails: %s', async (replyTo) => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-batch-emails',
+      arguments: {
+        emails: [
+          {
+            from: 'onboarding@resend.dev',
+            to: ['delivered@resend.dev'],
+            replyTo: [replyTo],
+            subject: 'hello',
+            text: 'world',
+          },
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(batchSend).toHaveBeenCalledWith(
+      [expect.objectContaining({ replyTo: [replyTo] })],
+      undefined,
+    );
+  });
+});
+
 describe('send-email idempotency key', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Display-name address support landed in pieces: batch `from` was fixed first, then single-email `from`, while `replyTo` continued using strict `z.email()` validation in both email tools. As a result, `Support Team <support@example.com>` was still rejected by the MCP before Resend could handle it.

This PR closes that remaining gap by aligning single and batch `replyTo` with the existing broadcast behavior. Bare and display-name values now reach the Resend SDK unchanged.

## Related fix history

| Reference | What it fixed or proposed | What remained afterward |
| --- | --- | --- |
| #134 | Proposed a custom mailbox schema for `from` and `replyTo` across single and batch sends. | Closed without merging because #162 was considered the simpler duplicate; none of its `replyTo` changes landed. |
| #161 | Reported the display-name failure on `send-email` `from` and suggested symmetric treatment for `replyTo`. | Closed after #162, although #162 did not change the reported single-email path or either `replyTo` schema. |
| #162 | Changed only `send-batch-emails` `from` from `z.email()` to `z.string()`. | `send-email` `from` and both `replyTo` schemas still rejected display-name values. |
| #185 | Fixed display-name `from` for `send-email`. | `replyTo` still used `z.email()` in both `send-email` and `send-batch-emails`. |

## Final gap closed by this PR

| Tool | Before | After |
| --- | --- | --- |
| `send-email` | Display-name `replyTo` rejected during MCP validation. | Bare and display-name `replyTo` strings are forwarded unchanged. |
| `send-batch-emails` | Display-name `replyTo` rejected for each batch item. | Bare and display-name `replyTo` strings are forwarded unchanged per item. |

## Why this matters

- Human users can provide a recognizable reply-to identity instead of exposing only a bare mailbox.
- Agent clients no longer receive an MCP invalid-arguments error for a value the SDK is designed to pass through.
- Validation behavior is now consistent across single sends, batch sends, and broadcasts.

The scope remains narrow: `to`, `cc`, and `bcc` retain strict email validation, no custom mailbox parser is introduced, and Resend remains responsible for validating the reply-to strings it receives.

## Validation

- `pnpm exec biome check --write .`
- `pnpm lint` (passes; two existing optional-chain warnings remain in unrelated files)
- `pnpm test tests/tools/emails.test.ts` (13 passed)
- `pnpm test` (116 passed across 13 files)
- `pnpm build`

Regression coverage verifies bare and display-name reply-to values for both tools, including the exact payload passed to the SDK mock.
