### PR TITLE
fix: remove unsupported batch scheduling

### DIFF
--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -1015,12 +1015,6 @@ export function addEmailTools(
                 .array(z.email())
                 .optional()
                 .describe('BCC email addresses'),
-              scheduledAt: z
-                .string()
-                .optional()
-                .describe(
-                  "Optional schedule time. Uses natural language (e.g., 'tomorrow at 10am') or ISO 8601.",
-                ),
               tags: z
                 .array(
                   z.object({
@@ -1076,7 +1070,6 @@ export function addEmailTools(
         if (email.html) request.html = email.html;
         if (email.cc) request.cc = email.cc;
         if (email.bcc) request.bcc = email.bcc;
-        if (email.scheduledAt) request.scheduledAt = email.scheduledAt;
         if (email.tags && email.tags.length > 0) request.tags = email.tags;
         if (email.topicId) request.topicId = email.topicId;
         if (email.headers && Object.keys(email.headers).length > 0) {

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -260,6 +260,49 @@ describe('send-batch-emails idempotency key', () => {
   });
 });
 
+describe('send-batch-emails scheduling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    batchSend.mockResolvedValue({
+      data: { data: [{ id: 'email_1' }] },
+      error: null,
+    });
+  });
+
+  it('does not advertise scheduledAt in the batch email input schema', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const batchTool = tools.find((tool) => tool.name === 'send-batch-emails');
+
+    expect(batchTool).toBeDefined();
+    expect(batchTool?.inputSchema).not.toHaveProperty(
+      'properties.emails.items.properties.scheduledAt',
+    );
+  });
+
+  it('does not pass stale scheduledAt input to the SDK batch payload', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-batch-emails',
+      arguments: {
+        emails: [
+          {
+            from: 'onboarding@resend.dev',
+            to: ['foo@example.com'],
+            subject: 'hello',
+            text: 'one',
+            scheduledAt: 'tomorrow at 10am',
+          },
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [[payload]] = batchSend.mock.calls[0];
+    expect(payload).not.toHaveProperty('scheduledAt');
+  });
+});
+
 describe('send-email custom headers', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

- Remove `scheduledAt` from each `send-batch-emails` item schema.
- Stop forwarding `scheduledAt` to `resend.batch.send`.
- Add regression coverage for both the public tool schema and stale client input.

## Why

The MCP currently accepts batch scheduling and forwards it to the API, but the [Resend batch API documentation](https://resend.com/docs/api-reference/emails/send-batch-emails#limitations) states that `scheduled_at` is not supported. Calls therefore pass MCP validation and fail at the API boundary.

## Scope

This is a focused batch-only fix. Single-email scheduling remains supported. Batch attachments and all other email fields are out of scope.

## Tests

- `pnpm exec vitest run tests/tools/emails.test.ts` (15 passed)
- `pnpm exec biome check --write .`
- `pnpm lint`
- `pnpm test` (118 passed)
- `pnpm build`