### PR TITLE
chore: bump resend to 6.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.17.1",
+    "resend": "6.18.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.17.1
-        version: 6.17.1
+        specifier: 6.18.0
+        version: 6.18.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -788,8 +788,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postal-mime@2.7.4:
-    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -815,8 +815,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.17.1:
-    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
+  resend@6.18.0:
+    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1626,7 +1626,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postal-mime@2.7.4: {}
+  postal-mime@2.7.5: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1654,9 +1654,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resend@6.17.1:
+  resend@6.18.0:
     dependencies:
-      postal-mime: 2.7.4
+      postal-mime: 2.7.5
       standardwebhooks: 1.0.0
 
   rollup@4.57.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
-  - resend@6.17.1
+  - resend


### PR DESCRIPTION
## Summary
- Bump the `resend` SDK from 6.17.1 to 6.18.0, which adds `scheduledAt` to the batch send types (resend/resend-node#1022). The `send-batch-emails` tool already passes `scheduledAt` and `tags` through in camelCase, so runtime behavior is unchanged — this aligns the types.
- Exclude `resend` from the pnpm minimum release age policy by package name (was pinned to `resend@6.17.1`), so future bumps of our own SDK skip the age gate instead of accumulating versioned entries.

## Testing
- `pnpm lint` — passes (2 pre-existing warnings)
- `tsc --noEmit` — clean
- `pnpm test` — 116/116 pass