### PR TITLE
fix: reject empty idempotency keys

### DIFF
--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -130,10 +130,11 @@ export function addEmailTools(
           ),
         idempotencyKey: z
           .string()
+          .min(1)
           .max(256)
           .optional()
           .describe(
-            'Optional unique key that prevents duplicate sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same logical email; use a new key for a different email. Max 256 characters.',
+            'Optional unique key that prevents duplicate sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same logical email; use a new key for a different email. Must be 1-256 characters.',
           ),
         // If sender email address is not provided, the tool requires it as an argument
         ...(!senderEmailAddress
@@ -1047,10 +1048,11 @@ export function addEmailTools(
           .describe('Array of email objects to send (1-100 emails)'),
         idempotencyKey: z
           .string()
+          .min(1)
           .max(256)
           .optional()
           .describe(
-            'Optional unique key for the whole batch that prevents duplicate batch sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same batch; use a new key for a different batch. Max 256 characters.',
+            'Optional unique key for the whole batch that prevents duplicate batch sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same batch; use a new key for a different batch. Must be 1-256 characters.',
           ),
       },
     },

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -199,6 +199,23 @@ describe('send-email idempotency key', () => {
 
     expect(send).toHaveBeenCalledWith(expect.any(Object), undefined);
   });
+
+  it('rejects an empty idempotencyKey before calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-email',
+      arguments: {
+        from: 'onboarding@resend.dev',
+        to: ['delivered@resend.dev'],
+        subject: 'hello',
+        text: 'world',
+        idempotencyKey: '',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+  });
 });
 
 describe('send-batch-emails idempotency key', () => {
@@ -257,6 +274,27 @@ describe('send-batch-emails idempotency key', () => {
     });
 
     expect(batchSend).toHaveBeenCalledWith(expect.any(Array), undefined);
+  });
+
+  it('rejects an empty idempotencyKey before calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'send-batch-emails',
+      arguments: {
+        emails: [
+          {
+            from: 'onboarding@resend.dev',
+            to: ['foo@example.com'],
+            subject: 'hello',
+            text: 'one',
+          },
+        ],
+        idempotencyKey: '',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(batchSend).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

An empty `idempotencyKey` currently passes MCP validation for both `send-email` and `send-batch-emails`. Because the handlers only forward truthy keys, `""` is silently treated as if the option was omitted, allowing the email request to proceed without the retry protection the caller requested.

Resend documents `invalid_idempotency_key` for keys outside 1–256 characters. This aligns both MCP schemas and their tool descriptions with that API contract.

Documentation: https://resend.com/docs/dashboard/emails/idempotency-keys#possible-responses

## Before and after

| | Empty `idempotencyKey` | Resend SDK called |
|---|---|---|
| Before | Accepted by MCP | Yes, without idempotency options |
| After | Rejected by MCP validation | No |

## Test evidence

- Before the schema fix, the two new regression tests failed: `2 failed, 13 passed`; both calls returned no `isError`.
- After the fix, the focused email suite passes: `15 passed`.
- Revert verification: removing only `.min(1)` made the same two tests fail again; restoring it returned them to green.
- Stability check: the focused suite passed 10 consecutive runs.
- Full suite: `138 passed`.
- `pnpm lint`: passed with two pre-existing optional-chain warnings.
- `pnpm build`: passed.
