### PR TITLE
fix: preserve `''` empty template/broadcast text

### DIFF
--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { Resend } from 'resend';
+import type { CreateBroadcastOptions, Resend } from 'resend';
 import { z } from 'zod';
 import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
 import type { ResendEditorClient } from '../lib/resend-editor-client.js';
@@ -55,9 +55,9 @@ export function addBroadcastTools(
         subject: z.string().nonempty().describe('Email subject'),
         text: z
           .string()
-          .nonempty()
+          .optional()
           .describe(
-            'Plain text version of the email content. The following placeholders may be used to personalize the email content: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}',
+            'Plain text version of the email content. The following placeholders may be used to personalize the email content: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
           ),
         html: z
           .string()
@@ -71,21 +71,21 @@ export function addBroadcastTools(
           .describe('Preview text for the email'),
         ...(!senderEmailAddress
           ? {
-              from: z
-                .string()
-                .nonempty()
-                .describe(
-                  'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
-                ),
-            }
+            from: z
+              .string()
+              .nonempty()
+              .describe(
+                'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
+              ),
+          }
           : {}),
         ...(replierEmailAddresses.length === 0
           ? {
-              replyTo: z
-                .array(z.string())
-                .optional()
-                .describe('Reply-to email address(es)'),
-            }
+            replyTo: z
+              .array(z.string())
+              .optional()
+              .describe('Reply-to email address(es)'),
+          }
           : {}),
       },
     },
@@ -116,16 +116,34 @@ export function addBroadcastTools(
         throw new Error('replyTo argument must be provided.');
       }
 
-      const response = await resend.broadcasts.create({
-        name,
-        segmentId,
-        subject,
-        text,
-        html,
-        previewText,
-        from: fromEmailAddress,
-        replyTo: replyToEmailAddresses,
-      });
+      var options: CreateBroadcastOptions;
+
+      if (html) {
+        options = {
+          name,
+          segmentId,
+          subject,
+          html,
+          ...(text !== undefined && { text }),
+          previewText,
+          from: fromEmailAddress,
+          replyTo: replyToEmailAddresses,
+        };
+      } else if (text !== undefined) {
+        options = {
+          name,
+          segmentId,
+          subject,
+          text,
+          previewText,
+          from: fromEmailAddress,
+          replyTo: replyToEmailAddresses,
+        };
+      } else {
+        throw new Error('either the html argument or the text argument must be provided.');
+      }
+
+      const response = await resend.broadcasts.create(options);
 
       if (response.error) {
         throw new Error(

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -71,21 +71,21 @@ export function addBroadcastTools(
           .describe('Preview text for the email'),
         ...(!senderEmailAddress
           ? {
-            from: z
-              .string()
-              .nonempty()
-              .describe(
-                'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
-              ),
-          }
+              from: z
+                .string()
+                .nonempty()
+                .describe(
+                  'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
+                ),
+            }
           : {}),
         ...(replierEmailAddresses.length === 0
           ? {
-            replyTo: z
-              .array(z.string())
-              .optional()
-              .describe('Reply-to email address(es)'),
-          }
+              replyTo: z
+                .array(z.string())
+                .optional()
+                .describe('Reply-to email address(es)'),
+            }
           : {}),
       },
     },
@@ -140,7 +140,9 @@ export function addBroadcastTools(
           replyTo: replyToEmailAddresses,
         };
       } else {
-        throw new Error('either the html argument or the text argument must be provided.');
+        throw new Error(
+          'either the html argument or the text argument must be provided.',
+        );
       }
 
       const response = await resend.broadcasts.create(options);

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -79,7 +79,7 @@ export function addTemplateTools(
           .string()
           .optional()
           .describe(
-            'Plain text version of the message. If not provided, HTML will be used to generate it.',
+            'Plain text version of the message. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
           ),
         alias: z
           .string()
@@ -100,7 +100,7 @@ export function addTemplateTools(
         ...(subject && { subject }),
         ...(from && { from }),
         ...(replyTo && { replyTo }),
-        ...(text && { text }),
+        ...(text !== undefined && { text }),
         ...(alias && { alias }),
         ...(variables && { variables }),
       } as CreateTemplateOptions);
@@ -465,7 +465,9 @@ export function addTemplateTools(
         text: z
           .string()
           .optional()
-          .describe('New plain text version of the message.'),
+          .describe(
+            'New plain text version of the message. Pass an empty string to disable automatic text generation.',
+          ),
         alias: z.string().optional().describe('New alias for the template.'),
         variables: z
           .array(templateVariableSchema)
@@ -493,7 +495,7 @@ export function addTemplateTools(
         ...(subject && { subject }),
         ...(from && { from }),
         ...(replyTo && { replyTo }),
-        ...(text && { text }),
+        ...(text !== undefined && { text }),
         ...(alias && { alias }),
         ...(variables && { variables }),
       } as UpdateTemplateOptions);

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -1,0 +1,76 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResendEditorClient } from '../../src/lib/resend-editor-client.js';
+import { addTemplateTools } from '../../src/tools/templates.js';
+
+const create = vi.fn();
+const update = vi.fn();
+
+const resend = {
+  templates: { create, update },
+} as unknown as Resend;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addTemplateTools(server, resend, {} as ResendEditorClient, {
+    withEditorSession: async (_connection, fn) => fn(),
+  });
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+describe('template text content', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    create.mockResolvedValue({
+      data: { id: 'tmpl_1' },
+      error: null,
+    });
+    update.mockResolvedValue({
+      data: { id: 'tmpl_1' },
+      error: null,
+    });
+  });
+
+  it('passes empty text through create-template', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'create-template',
+      arguments: {
+        name: 'Welcome',
+        html: '<p>Hello</p>',
+        text: '',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(create).toHaveBeenCalledWith({
+      name: 'Welcome',
+      html: '<p>Hello</p>',
+      text: '',
+    });
+  });
+
+  it('passes empty text through update-template', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'update-template',
+      arguments: {
+        id: 'tmpl_1',
+        text: '',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(update).toHaveBeenCalledWith('tmpl_1', { text: '' });
+  });
+});


### PR DESCRIPTION
## Summary

- preserve an explicitly empty `text` value in `create-template` and `update-template`
- document that `text: ""` disables automatic plain-text generation
- add MCP-level regression coverage for both template operations

## Why

Resend treats an omitted `text` field and an empty string differently. Omitting it allows Resend to generate a plain-text version from the HTML, while an empty string opts out of that behavior.

The template tools used truthiness checks when constructing SDK payloads, so `text: ""` was silently discarded even though it passed input validation. Checking specifically for `undefined` preserves the documented API semantics.

References:

- https://resend.com/docs/api-reference/templates/create-template
- https://resend.com/docs/api-reference/templates/update-template

## Validation

- `pnpm lint`
- `pnpm test` — 140 tests passed
- `pnpm build`
