### PR TITLE
chore: annotate read-only tools with readOnlyHint

### DIFF
--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -63,6 +63,7 @@ export function addApiKeyTools(server: McpServer, resend: Resend) {
     'list-api-keys',
     {
       title: 'List API Keys',
+      annotations: { readOnlyHint: true },
       description:
         "List all API keys from Resend. Returns API key names, IDs, and creation dates. Don't bother telling the user the IDs or creation dates unless they ask for them.",
       inputSchema: {

--- a/src/tools/automations.ts
+++ b/src/tools/automations.ts
@@ -280,6 +280,7 @@ ${WORKFLOW_GUIDANCE}`,
     'get-automation',
     {
       title: 'Get Automation',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** Get details of a specific automation (with its workflow) or list all automations.
 
 **Modes:**
@@ -447,6 +448,7 @@ ${WORKFLOW_GUIDANCE}`,
     'get-automation-runs',
     {
       title: 'Get Automation Runs',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List runs for an automation, or get details of a specific run.
 
 **Modes:**

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -215,6 +215,7 @@ export function addBroadcastTools(
     'list-broadcasts',
     {
       title: 'List Broadcasts',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List all broadcast campaigns (newsletters/bulk emails to audiences) with ID, name, audience, status, timestamps.
 
 **NOT for:** Listing transactional emails (use list-emails). Not for listing segments or contacts (use list-segments, list-contacts).
@@ -273,6 +274,7 @@ export function addBroadcastTools(
     'get-broadcast',
     {
       title: 'Get Broadcast',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve full details of a specific broadcast by ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>), including HTML and plain text content.',
       inputSchema: {

--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -168,6 +168,7 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
     'get-contact-import',
     {
       title: 'Get Contact Import',
+      annotations: { readOnlyHint: true },
       description:
         'Get the status and counts of a contact import by ID. Use after create-contact-import to track progress (queued, in_progress, completed, failed).',
       inputSchema: {
@@ -212,6 +213,7 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
     'list-contact-imports',
     {
       title: 'List Contact Imports',
+      annotations: { readOnlyHint: true },
       description:
         'List contact imports from Resend. Optionally filter by status. Use to discover import IDs or review past imports.',
       inputSchema: {

--- a/src/tools/contactProperties.ts
+++ b/src/tools/contactProperties.ts
@@ -57,6 +57,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
     'list-contact-properties',
     {
       title: 'List Contact Properties',
+      annotations: { readOnlyHint: true },
       description:
         "List all contact properties from Resend. This tool is useful for getting property IDs and seeing which custom attributes are configured. If you need a contact property ID, you MUST use this tool to get all available properties and then ask the user to select the one they want. Don't bother telling the user the IDs or creation dates unless they ask for them.",
       inputSchema: {
@@ -141,6 +142,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
     'get-contact-property',
     {
       title: 'Get Contact Property',
+      annotations: { readOnlyHint: true },
       description: 'Get a contact property by ID from Resend.',
       inputSchema: {
         contactPropertyId: z

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -84,6 +84,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'list-contacts',
     {
       title: 'List Contacts',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List contacts from Resend. Optionally filter by segment. Use to discover contact IDs or emails.
 
 **NOT for:** Listing segments (use list-segments). Not for listing sent emails (use list-emails) or broadcasts (use list-broadcasts).
@@ -198,6 +199,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'get-contact',
     {
       title: 'Get Contact',
+      annotations: { readOnlyHint: true },
       description: 'Get a contact by ID or email from Resend.',
       inputSchema: {
         id: z.string().optional().describe('Contact ID'),
@@ -447,6 +449,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'list-contact-segments',
     {
       title: 'List Contact Segments',
+      annotations: { readOnlyHint: true },
       description:
         "List all segments a contact belongs to in Resend (by contact ID or email). Don't bother telling the user the IDs or creation dates unless they ask for them.",
       inputSchema: {
@@ -544,6 +547,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
     'list-contact-topics',
     {
       title: 'List Contact Topics',
+      annotations: { readOnlyHint: true },
       description:
         "List all topic subscriptions for a contact in Resend (by contact ID or email). Don't bother telling the user the IDs unless they ask for them.",
       inputSchema: {

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -141,6 +141,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     'list-domains',
     {
       title: 'List Domains',
+      annotations: { readOnlyHint: true },
       description:
         "List all domains from Resend. Returns domain names, statuses, regions, and capabilities. Don't bother telling the user the IDs unless they ask for them.",
       inputSchema: {
@@ -225,6 +226,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     'get-domain',
     {
       title: 'Get Domain',
+      annotations: { readOnlyHint: true },
       description:
         'Get a domain by ID from Resend. Returns full domain details including DNS records needed for verification.',
       inputSchema: {
@@ -475,6 +477,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     'get-domain-claim',
     {
       title: 'Get Domain Claim',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve the latest claim for a domain by its placeholder Domain ID (the domain_id from create-domain-claim). Returns claim status and the TXT record needed to prove ownership. Poll until status is "completed".',
       inputSchema: {

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -66,6 +66,7 @@ export function addEditorTools(
     'get-tiptap-json-content',
     {
       title: 'Get TipTap JSON Content',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** Retrieve the existing TipTap JSON content of a broadcast or template, optionally bundled with the TipTap schema reference. Also connects the agent to the editor so the avatar is visible while content is being generated.
 
 **When to use:**

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -312,6 +312,7 @@ export function addEmailTools(
     'list-emails',
     {
       title: 'List Emails',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List recently sent emails (transactional emails sent via send-email) with metadata: recipient, subject, status, timestamps.
 
 **NOT for:** Listing broadcast campaigns (use list-broadcasts). Not for composing or sending.
@@ -410,6 +411,7 @@ export function addEmailTools(
     'get-email',
     {
       title: 'Get Email',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve full details of a specific sent transactional email by ID, including message_id, HTML and plain text content.',
       inputSchema: {
@@ -480,6 +482,7 @@ export function addEmailTools(
     'list-received-emails',
     {
       title: 'List Received Emails',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List emails received (inbox) by your Resend receiving address. Use for "show my inbox", "what emails did I get?", "list incoming mail".
 
 **NOT for:** Listing emails you sent (use list-emails). Not for listing broadcasts (use list-broadcasts).
@@ -570,6 +573,7 @@ export function addEmailTools(
     'get-received-email',
     {
       title: 'Get Received Email',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve full details of a specific received email by ID, including HTML and plain text content, headers, and raw email download URL.',
       inputSchema: {
@@ -644,6 +648,7 @@ export function addEmailTools(
     'list-received-email-attachments',
     {
       title: 'List Received Email Attachments',
+      annotations: { readOnlyHint: true },
       description:
         'List all attachments from a specific received (inbox) email. Returns attachment metadata including filename, size, content type, and a time-limited download URL. Use for emails listed by list-received-emails.',
       inputSchema: {
@@ -728,6 +733,7 @@ export function addEmailTools(
     'get-received-email-attachment',
     {
       title: 'Get Received Email Attachment',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve details of a specific attachment from a received email, including a time-limited download URL.',
       inputSchema: {
@@ -845,6 +851,7 @@ export function addEmailTools(
     'list-sent-email-attachments',
     {
       title: 'List Sent Email Attachments',
+      annotations: { readOnlyHint: true },
       description:
         'List all attachments from a specific sent email (from send-email or list-emails). Returns attachment metadata including filename, size, content type, and a time-limited download URL.',
       inputSchema: {
@@ -928,6 +935,7 @@ export function addEmailTools(
     'get-sent-email-attachment',
     {
       title: 'Get Sent Email Attachment',
+      annotations: { readOnlyHint: true },
       description:
         'Retrieve details of a specific attachment from a sent email, including a time-limited download URL.',
       inputSchema: {

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -7,6 +7,7 @@ export function addLogTools(server: McpServer, resend: Resend) {
     'list-logs',
     {
       title: 'List Logs',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List API request logs for the account. Use to review recent API activity, debug issues, or audit API usage.
 
 **Returns:** For each log: id, created_at, endpoint, method, response_status, user_agent. Use pagination (limit, after/before) for large lists.
@@ -106,6 +107,7 @@ export function addLogTools(server: McpServer, resend: Resend) {
     'get-log',
     {
       title: 'Get Log',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** Get detailed information about a specific API request log, including the full request and response bodies.
 
 **Returns:** Log details: id, created_at, endpoint, method, response_status, user_agent, request_body, response_body.

--- a/src/tools/oauthGrants.ts
+++ b/src/tools/oauthGrants.ts
@@ -7,6 +7,7 @@ export function addOAuthGrantTools(server: McpServer, resend: Resend) {
     'list-oauth-grants',
     {
       title: 'List OAuth Grants',
+      annotations: { readOnlyHint: true },
       description:
         "List OAuth grants for the team — the apps authorized to act on the team's behalf. Returns every grant, active and revoked; a grant with a non-null revoked_at is no longer active. Each grant includes the client (app) name, scopes, and creation date. Don't bother telling the user the IDs unless they ask for them.",
       inputSchema: {

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -36,6 +36,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     'list-segments',
     {
       title: 'List Segments',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List all segments in the account. Use to get segment IDs required by create-contact, create-broadcast, list-contacts.
 
 **NOT for:** Listing contacts inside a segment (use list-contacts with segmentId). Not for listing broadcasts (use list-broadcasts).
@@ -125,6 +126,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     'get-segment',
     {
       title: 'Get Segment',
+      annotations: { readOnlyHint: true },
       description: 'Get a segment by ID from Resend.',
       inputSchema: {
         id: z.string().nonempty().describe('Segment ID'),

--- a/src/tools/suppressions.ts
+++ b/src/tools/suppressions.ts
@@ -45,6 +45,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
     'list-suppressions',
     {
       title: 'List Suppressions',
+      annotations: { readOnlyHint: true },
       description: `**Purpose:** List email addresses on the suppression list. Suppressed addresses never receive emails from the account. Optionally filter by origin: "bounce" (added automatically after a hard bounce), "complaint" (added automatically after a spam complaint), or "manual" (added via the API or dashboard).
 
 **NOT for:** Checking a single address (use get-suppression). Not for listing contacts (use list-contacts).
@@ -145,6 +146,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
     'get-suppression',
     {
       title: 'Get Suppression',
+      annotations: { readOnlyHint: true },
       description:
         'Get a suppression list entry by ID or email address from Resend. Use this to check whether a specific address is suppressed and why (origin: bounce, complaint, or manual).',
       inputSchema: {

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -132,6 +132,7 @@ export function addTemplateTools(
     'list-templates',
     {
       title: 'List Templates',
+      annotations: { readOnlyHint: true },
       description:
         "List all email templates from Resend. Returns template names, statuses, and aliases. Don't bother telling the user the IDs unless they ask for them.",
       inputSchema: {
@@ -216,6 +217,7 @@ export function addTemplateTools(
     'get-template',
     {
       title: 'Get Template',
+      annotations: { readOnlyHint: true },
       description:
         'Get an email template by ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>) from Resend. Returns full template details including HTML content, variables, and publish status.',
       inputSchema: {

--- a/src/tools/topics.ts
+++ b/src/tools/topics.ts
@@ -54,6 +54,7 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     'list-topics',
     {
       title: 'List Topics',
+      annotations: { readOnlyHint: true },
       description:
         'List all topics from Resend. This tool is useful for getting topic IDs to use with other tools like send-email.',
       inputSchema: {},
@@ -94,6 +95,7 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     'get-topic',
     {
       title: 'Get Topic',
+      annotations: { readOnlyHint: true },
       description: 'Get a topic by ID from Resend.',
       inputSchema: {
         id: z.string().nonempty().describe('Topic ID'),

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -67,6 +67,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     'list-webhooks',
     {
       title: 'List Webhooks',
+      annotations: { readOnlyHint: true },
       description:
         'List all webhooks from Resend. Use to get webhook IDs and see which endpoints and events are configured. Not for listing emails, segments, or broadcasts.',
       inputSchema: {},
@@ -100,6 +101,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     'get-webhook',
     {
       title: 'Get Webhook',
+      annotations: { readOnlyHint: true },
       description: 'Get a webhook by ID from Resend.',
       inputSchema: {
         webhookId: z.string().nonempty().describe('Webhook ID'),


### PR DESCRIPTION
The 38 `list-*` and `get-*` tools carry no `annotations`, so they inherit the MCP defaults. From the SDK's own schema docs:

- `readOnlyHint` — Default: **false**
- `destructiveHint` — Default: **true**

So a spec-compliant client currently has to assume `list-emails`, `get-contact`, and `list-domains` might modify or destroy something, and can prompt for confirmation before a plain read. This patch sets `readOnlyHint: true` on those 38, which declares what they already do.

Deliberately narrow:

- **Only `list-*` and `get-*` tools are touched.** All 53 mutating tools are left exactly as they are, so their conservative defaults stand. I did not set `destructiveHint: false` on anything, including creates, because that would reduce prompting on tools I do not own and cannot judge for you.
- **No new dependency, no behaviour change.** One key added to a config object per tool.
- `destructiveHint` is not set on the annotated tools, since the spec says it is only meaningful when `readOnlyHint == false`.

Verified on this branch: `npx tsc --noEmit` clean, `npm run lint` clean (2 pre-existing warnings, unrelated), `npm test` 138 passed.

Happy to cut this to a single file if you would rather review a smaller change first, or to close it if you would prefer to annotate these yourselves. Either is fine.