### PR TITLE
fix(security): remove local file paths from contact imports

### DIFF
--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Resend } from 'resend';
 import { z } from 'zod';
@@ -9,25 +8,19 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
     {
       title: 'Create Contact Import',
       description:
-        'Bulk-import contacts from a CSV file into Resend. The import is processed asynchronously: this returns an import ID immediately, then use get-contact-import to poll its status and counts. Provide the CSV via exactly one of `filePath`, `content`, or `url`. Max file size 100MB.',
+        'Bulk-import contacts from CSV content or a URL into Resend. The import is processed asynchronously: this returns an import ID immediately, then use get-contact-import to poll its status and counts. Provide exactly one of `content` or `url`. Max file size 100MB.',
       inputSchema: {
-        filePath: z
-          .string()
-          .optional()
-          .describe(
-            'Local path to a CSV file to read and upload. Use one of filePath, content, or url.',
-          ),
         content: z
           .string()
           .optional()
           .describe(
-            'Raw CSV text to upload (e.g. "email,first_name\\na@b.com,Ada"). Use one of filePath, content, or url.',
+            'Raw CSV text to upload (e.g. "email,first_name\\na@b.com,Ada"). Use one of content or url.',
           ),
         url: z
           .string()
           .optional()
           .describe(
-            'URL of a CSV file to fetch and upload. Use one of filePath, content, or url.',
+            'URL of a CSV file to fetch and upload. Use one of content or url.',
           ),
         filename: z
           .string()
@@ -99,7 +92,6 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
       },
     },
     async ({
-      filePath,
       content,
       url,
       filename,
@@ -108,19 +100,15 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
       segmentIds,
       topics,
     }) => {
-      const sources = [filePath, content, url].filter(
-        (s) => s !== undefined,
-      ).length;
+      const sources = [content, url].filter((s) => s !== undefined).length;
       if (sources !== 1) {
         throw new Error(
-          'Provide exactly one of "filePath", "content", or "url" for the CSV file.',
+          'Provide exactly one of "content" or "url" for the CSV file.',
         );
       }
 
       let fileData: BlobPart;
-      if (filePath !== undefined) {
-        fileData = await readFile(filePath);
-      } else if (url !== undefined) {
+      if (url !== undefined) {
         const res = await fetch(url);
         if (!res.ok) {
           throw new Error(

--- a/tests/tools/contactImports.test.ts
+++ b/tests/tools/contactImports.test.ts
@@ -105,6 +105,26 @@ describe('create-contact-import', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it('does not accept a local file path as an import source', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const tool = tools.find(
+      (candidate) => candidate.name === 'create-contact-import',
+    );
+    expect(tool?.inputSchema.properties).not.toHaveProperty('filePath');
+
+    const result = await client.callTool({
+      name: 'create-contact-import',
+      arguments: { filePath: '/etc/passwd' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      'Provide exactly one of "content" or "url"',
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('errors when multiple file sources are provided', async () => {
     const client = await makeClient();
     const result = await client.callTool({


### PR DESCRIPTION
## Summary

Removes the `filePath` input from `create-contact-import`.

This is an MCP-specific security issue, not a flaw in Resend’s contact-import API.

Resend’s API documentation shows normal application code reading a developer-chosen file such as `contacts.csv` and uploading its contents. That is safe in an application because the developer controls the path.

In this MCP server, however, `filePath` was an MCP tool argument. A caller or prompt-injection attack could supply any readable local path. The server would then read that file and upload its contents through the contact-import API.

For example, a readable customer CSV outside the intended working directory could be imported into the caller’s Resend account.

## Why this change is safe

The Resend contact-import API needs file *contents*, not an MCP `filePath` feature. The MCP tool can still import contacts through:

- `content` — CSV text supplied directly by the caller
- `url` — an existing remote CSV source

This preserves contact imports while removing the process-local arbitrary-file read capability.

Resend’s docs confirm that imports are supported through the API, CLI, and MCP:

- [Managing Contacts](https://resend.com/docs/dashboard/audiences/contacts)
- [Create Contact Import API](https://resend.com/docs/api-reference/contacts/create-contact-import)

## Changes

- Remove `filePath` from the MCP input schema.
- Remove the `readFile()` code path and filesystem import.
- Update descriptions and validation messages.
- Add a regression test confirming that `filePath` is not exposed and cannot invoke an import.

## Validation

- `pnpm test` — 141 passing
- `pnpm build`
- `pnpm lint` — passes with existing unrelated warnings in `src/cli/resolve.ts` and `src/transports/http.ts`