### PR TITLE
feat: support MCP spec 2026-07-28 alongside legacy clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Resend SDK to v6.1.0
 - Improve `list-audiences` response formatting
 
+## [3.0.0] - 2026-08-06
+
+### Added
+
+- Support for MCP protocol revision 2026-07-28 (stateless, per-request
+  clients) on both stdio and HTTP, alongside full backward compatibility
+  for existing (`initialize`-handshake) clients on both transports.
+
+### Changed
+
+- Migrated from MCP TypeScript SDK v1 (`@modelcontextprotocol/sdk`) to v2
+  (`@modelcontextprotocol/server`/`/node`/`/express`).
+
+### Breaking
+
+- The `McpServer` type returned by `createMcpServer` (exported from
+  `resend-mcp` and used internally by `resend-mcp/http`) now comes from
+  `@modelcontextprotocol/server` instead of `@modelcontextprotocol/sdk` —
+  a breaking type change for anyone importing this package as a library
+  and type-checking against it directly. `npx`/CLI usage is unaffected.
+
 ## [1.1.0] - 2025-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,27 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Resend SDK to v6.1.0
 - Improve `list-audiences` response formatting
 
-## [3.0.0] - 2026-08-06
-
-### Added
-
-- Support for MCP protocol revision 2026-07-28 (stateless, per-request
-  clients) on both stdio and HTTP, alongside full backward compatibility
-  for existing (`initialize`-handshake) clients on both transports.
-
-### Changed
-
-- Migrated from MCP TypeScript SDK v1 (`@modelcontextprotocol/sdk`) to v2
-  (`@modelcontextprotocol/server`/`/node`/`/express`).
-
-### Breaking
-
-- The `McpServer` type returned by `createMcpServer` (exported from
-  `resend-mcp` and used internally by `resend-mcp/http`) now comes from
-  `@modelcontextprotocol/server` instead of `@modelcontextprotocol/sdk` —
-  a breaking type change for anyone importing this package as a library
-  and type-checking against it directly. `npx`/CLI usage is unaffected.
-
 ## [1.1.0] - 2025-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ claude mcp add --transport http resend https://mcp.resend.com/mcp --header "Auth
 
 ## Local MCP Server
 
-The hosted server runs the same open-source code that's available on NPM as [`resend-mcp`](https://www.npmjs.com/package/resend-mcp). If you prefer to run the server yourself, you can integrate it into any supported MCP client using `npx`. You'll need to:
+The hosted server and this open-source package both implement the Model Context Protocol, including the same MCP spec 2026-07-28 support alongside legacy clients, but are maintained as separate implementations. If you prefer to run the server yourself, you can integrate it into any supported MCP client using `npx`. You'll need to:
 
 - [Create an API key](https://resend.com/api-keys)
 - [Verify your domain](https://resend.com/domains)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ claude mcp add --transport http resend https://mcp.resend.com/mcp --header "Auth
 
 ## Local MCP Server
 
-The hosted server and this open-source package both implement the Model Context Protocol, including the same MCP spec 2026-07-28 support alongside legacy clients, but are maintained as separate implementations. If you prefer to run the server yourself, you can integrate it into any supported MCP client using `npx`. You'll need to:
+The hosted server runs the same open-source code that's available on NPM as [`resend-mcp`](https://www.npmjs.com/package/resend-mcp). If you prefer to run the server yourself, you can integrate it into any supported MCP client using `npx`. You'll need to:
 
 - [Create an API key](https://resend.com/api-keys)
 - [Verify your domain](https://resend.com/domains)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.11.1",
+  "version": "3.0.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/express": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
@@ -42,6 +44,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/minimist": "1.2.5",
     "@types/node": "25.9.1",
     "typescript": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "3.0.0",
+  "version": "2.12.0",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -30,9 +30,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/express": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
-    "@modelcontextprotocol/server": "^2.0.0",
+    "@modelcontextprotocol/express": "2.0.0",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
-    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/minimist": "1.2.5",
     "@types/node": "25.9.1",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 1.29.0
-        version: 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/express':
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(express@5.2.1)
+      '@modelcontextprotocol/node':
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.5)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -30,6 +36,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.10
         version: 2.4.10
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/minimist':
         specifier: 1.2.5
         version: 1.2.5
@@ -267,15 +276,34 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/express@2.0.0':
+    resolution: {integrity: sha512-Snlr8j9FR9LcVvEJPF7qJ7d5zTL4Bes2dk7RcacN9eSZ7OLohwxqhEvWu1+UxELyScgLbLLOdeVEGdwKI1iwVQ==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      '@modelcontextprotocol/server': ^2.0.0
+      express: ^4.18.0 || ^5.0.0
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: ^4.11.4
     peerDependenciesMeta:
-      '@cfworker/json-schema':
+      hono:
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
@@ -469,17 +497,6 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -601,24 +618,12 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.2.1:
-    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -684,10 +689,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
-    engines: {node: '>= 12'}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -700,12 +701,6 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -810,10 +805,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
 
   resend@6.18.0:
     resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
@@ -1024,11 +1015,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
-    peerDependencies:
-      zod: ^3.25 || ^4
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -1153,27 +1139,37 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/client@2.0.0':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.5)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.5
+      '@modelcontextprotocol/core': 2.0.0
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.5
       jose: 6.1.3
-      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
-      raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/express@2.0.0(@modelcontextprotocol/server@2.0.0)(express@5.2.1)':
+    dependencies:
+      '@modelcontextprotocol/server': 2.0.0
+      cors: 2.8.5
+      express: 5.2.1
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.5)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.5)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.12.5
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
@@ -1315,17 +1311,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
-    optionalDependencies:
-      ajv: 8.17.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
   assertion-error@2.0.1: {}
 
   body-parser@2.2.2:
@@ -1450,11 +1435,6 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.2.1(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.0.1
-
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -1488,11 +1468,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-deep-equal@3.1.3: {}
-
   fast-sha256@1.3.0: {}
-
-  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -1560,8 +1536,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.0.1: {}
-
   ipaddr.js@1.9.1: {}
 
   is-promise@4.0.0: {}
@@ -1569,10 +1543,6 @@ snapshots:
   isexe@2.0.0: {}
 
   jose@6.1.3: {}
-
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1651,8 +1621,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       unpipe: 1.0.0
-
-  require-from-string@2.0.2: {}
 
   resend@6.18.0:
     dependencies:
@@ -1854,9 +1822,5 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
-
-  zod-to-json-schema@3.25.1(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/express':
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(express@5.2.1)
       '@modelcontextprotocol/node':
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.5)
       '@modelcontextprotocol/server':
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0
       dotenv:
         specifier: 17.4.2
@@ -37,7 +37,7 @@ importers:
         specifier: 2.4.10
         version: 2.4.10
       '@modelcontextprotocol/client':
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0
       '@types/minimist':
         specifier: 1.2.5

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import packageJson from '../package.json' with { type: 'json' };
 import { DashboardClient } from './lib/dashboard-client.js';

--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/automations.ts
+++ b/src/tools/automations.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 import { extractIdFromUrl } from '../lib/url-parser.js';

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
 import type { CreateBroadcastOptions, Resend } from 'resend';
 import { z } from 'zod';
 import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
@@ -19,6 +19,7 @@ export function addBroadcastTools(
     withEditorSession: <T>(
       conn: { resource_type: 'broadcast' | 'template'; resource_id: string },
       fn: () => Promise<T>,
+      ctx?: ServerContext,
     ) => Promise<T>;
   },
 ) {
@@ -245,7 +246,7 @@ export function addBroadcastTools(
 **When to use:** User asks "show my broadcasts", "what newsletters did I send?", "list campaigns". Use get-broadcast for full details of one.`,
       inputSchema: {},
     },
-    async () => {
+    async (_args, _ctx) => {
       const response = await resend.broadcasts.list();
 
       if (response.error) {
@@ -456,18 +457,16 @@ export function addBroadcastTools(
           .describe('Update the broadcast name (internal label).'),
       },
     },
-    async ({
-      broadcastId: rawBroadcastId,
-      content,
-      subject,
-      previewText,
-      name,
-    }) => {
+    async (
+      { broadcastId: rawBroadcastId, content, subject, previewText, name },
+      ctx,
+    ) => {
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
       // Compose the TipTap content with editor session
       await withEditorSession(
         { resource_type: 'broadcast', resource_id: broadcastId },
         () => apiClient.composeBroadcastContent(broadcastId, { content }),
+        ctx,
       );
 
       // Update metadata if any was provided

--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/contactProperties.ts
+++ b/src/tools/contactProperties.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type {
   GetContactResponse,
   RemoveContactsResponse,

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -18,7 +18,6 @@ export function addEditorTools(
 ) {
   let activeConnection: EditorConnection | null = null;
 
-  /** Client identity for editor-presence: modern per-request envelope, else the legacy getClientVersion() fallback. */
   function getAgentName(ctx?: ServerContext): string | undefined {
     const envelope = ctx?.mcpReq.envelope as
       | Record<typeof CLIENT_INFO_META_KEY, { name?: string } | undefined>

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -1,4 +1,5 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
+import { CLIENT_INFO_META_KEY } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import type { DashboardClient } from '../lib/dashboard-client.js';
 import type { ResendEditorClient } from '../lib/resend-editor-client.js';
@@ -17,9 +18,21 @@ export function addEditorTools(
 ) {
   let activeConnection: EditorConnection | null = null;
 
-  /** MCP client name (e.g. "claude-code", "cursor") used as the agent_name for editor presence. */
-  function getAgentName(): string | undefined {
-    return server.server.getClientVersion()?.name;
+  /**
+   * MCP client name (e.g. "claude-code", "cursor") used as the agent_name for
+   * editor presence. A modern (2026-07-28) request carries its own per-request
+   * `clientInfo` in `ctx.mcpReq.envelope`; `getClientVersion()` is only
+   * populated from a persistent connection's `initialize` handshake, which a
+   * stateless modern stdio/HTTP exchange never sends.
+   */
+  function getAgentName(ctx?: ServerContext): string | undefined {
+    const envelope = ctx?.mcpReq.envelope as
+      | Record<typeof CLIENT_INFO_META_KEY, { name?: string } | undefined>
+      | undefined;
+    return (
+      envelope?.[CLIENT_INFO_META_KEY]?.name ??
+      server.server.getClientVersion()?.name
+    );
   }
 
   /**
@@ -30,6 +43,7 @@ export function addEditorTools(
   async function withEditorSession<T>(
     conn: EditorConnection,
     fn: () => Promise<T>,
+    ctx?: ServerContext,
   ): Promise<T> {
     if (!apiClient) {
       return fn();
@@ -42,7 +56,7 @@ export function addEditorTools(
 
     if (!alreadyConnected) {
       try {
-        const agent_name = conn.agent_name ?? getAgentName();
+        const agent_name = conn.agent_name ?? getAgentName(ctx);
         await apiClient.createEditorConnection({ ...conn, agent_name });
         activeConnection = { ...conn, agent_name };
       } catch {
@@ -97,7 +111,10 @@ export function addEditorTools(
           ),
       },
     },
-    async ({ resource_type, resource_id: rawResourceId, include_schema }) => {
+    async (
+      { resource_type, resource_id: rawResourceId, include_schema },
+      ctx,
+    ) => {
       const resource_id = extractIdFromUrl(
         rawResourceId,
         resource_type === 'broadcast' ? 'broadcasts' : 'templates',
@@ -111,7 +128,7 @@ export function addEditorTools(
         activeConnection.resource_type !== resource_type ||
         activeConnection.resource_id !== resource_id
       ) {
-        const agent_name = getAgentName();
+        const agent_name = getAgentName(ctx);
         try {
           await apiClient.createEditorConnection({
             resource_type,
@@ -182,7 +199,7 @@ export function addEditorTools(
           .describe('Display name for the agent avatar'),
       },
     },
-    async ({ resource_type, resource_id: rawResourceId, agent_name }) => {
+    async ({ resource_type, resource_id: rawResourceId, agent_name }, ctx) => {
       if (!apiClient) {
         throw new Error('API client not configured. Provide a Resend API key.');
       }
@@ -192,7 +209,7 @@ export function addEditorTools(
         resource_type === 'broadcast' ? 'broadcasts' : 'templates',
       );
 
-      const resolvedAgentName = agent_name ?? getAgentName();
+      const resolvedAgentName = agent_name ?? getAgentName(ctx);
 
       const result = await apiClient.createEditorConnection({
         resource_type,
@@ -224,7 +241,7 @@ export function addEditorTools(
         'Remove agent presence from the Resend dashboard editor. Call this when done editing.',
       inputSchema: {},
     },
-    async () => {
+    async (_args, _ctx) => {
       if (!apiClient) {
         throw new Error('API client not configured. Provide a Resend API key.');
       }

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -18,13 +18,7 @@ export function addEditorTools(
 ) {
   let activeConnection: EditorConnection | null = null;
 
-  /**
-   * MCP client name (e.g. "claude-code", "cursor") used as the agent_name for
-   * editor presence. A modern (2026-07-28) request carries its own per-request
-   * `clientInfo` in `ctx.mcpReq.envelope`; `getClientVersion()` is only
-   * populated from a persistent connection's `initialize` handshake, which a
-   * stateless modern stdio/HTTP exchange never sends.
-   */
+  /** Client identity for editor-presence: modern per-request envelope, else the legacy getClientVersion() fallback. */
   function getAgentName(ctx?: ServerContext): string | undefined {
     const envelope = ctx?.mcpReq.envelope as
       | Record<typeof CLIENT_INFO_META_KEY, { name?: string } | undefined>

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/oauthGrants.ts
+++ b/src/tools/oauthGrants.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/suppressions.ts
+++ b/src/tools/suppressions.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend, SuppressionListEntry } from 'resend';
 import { z } from 'zod';
 

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
 import type {
   CreateTemplateOptions,
   Resend,
@@ -37,6 +37,7 @@ export function addTemplateTools(
     withEditorSession: <T>(
       conn: { resource_type: 'broadcast' | 'template'; resource_id: string },
       fn: () => Promise<T>,
+      ctx?: ServerContext,
     ) => Promise<T>;
   },
 ) {
@@ -321,12 +322,13 @@ export function addTemplateTools(
         name: z.string().optional().describe('Update the template name.'),
       },
     },
-    async ({ id: rawId, content, subject, name }) => {
+    async ({ id: rawId, content, subject, name }, ctx) => {
       const id = extractIdFromUrl(rawId, 'templates');
       // Compose the TipTap content with editor session
       await withEditorSession(
         { resource_type: 'template', resource_id: id },
         () => apiClient.composeTemplateContent(id, { content }),
+        ctx,
       );
 
       // Update metadata if any was provided

--- a/src/tools/topics.ts
+++ b/src/tools/topics.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
@@ -59,7 +59,7 @@ export function addTopicTools(server: McpServer, resend: Resend) {
         'List all topics from Resend. This tool is useful for getting topic IDs to use with other tools like send-email.',
       inputSchema: {},
     },
-    async () => {
+    async (_args, _ctx) => {
       const response = await resend.topics.list();
 
       if (response.error) {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
@@ -72,7 +72,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
         'List all webhooks from Resend. Use to get webhook IDs and see which endpoints and events are configured. Not for listing emails, segments, or broadcasts.',
       inputSchema: {},
     },
-    async () => {
+    async (_args, _ctx) => {
       const response = await resend.webhooks.list();
 
       if (response.error) {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -44,7 +44,7 @@ function extractBearerToken(req: IncomingMessage): string | null {
   return token || null;
 }
 
-/** Same as `extractBearerToken`, for the Web-standard `Request` the modern leg deals in. */
+/** Same as `extractBearerToken`, for the modern leg's Web-standard `Request`. */
 function extractBearerTokenFromWebRequest(req: Request): string | null {
   const header = req.headers.get('authorization');
   if (!header || !header.startsWith('Bearer ')) return null;
@@ -81,11 +81,9 @@ export interface HttpTransportOptions {
  * remote deployment where each user authenticates with their own API key
  * instead of a single server-side key.
  *
- * Legacy (pre-2026-07-28, `initialize`-handshake) clients are served exactly
- * as before, via the sessionful `sessions` map below. Modern (2026-07-28)
- * clients are stateless by protocol design — no `initialize`, no session ID
- * — so they're served by a separate, additive `createMcpHandler` leg,
- * dispatched per request via `isLegacyRequest`.
+ * Legacy clients keep the sessionful path below unchanged; modern
+ * (2026-07-28) clients are stateless by protocol design, so they're routed
+ * to a separate, additive `createMcpHandler` leg via `isLegacyRequest`.
  */
 export async function runHttp(
   options: ServerOptions,
@@ -100,12 +98,8 @@ export async function runHttp(
     res.end(JSON.stringify({ status: 'ok' }));
   });
 
-  // The auth check happens here, before dispatching into modernHandler, so a
-  // missing key gets the same 401 shape as the legacy leg's — a factory
-  // `throw` is converted by createMcpHandler into a generic 500 instead.
-  // `legacy: 'reject'` keeps exactly one source of truth for legacy serving
-  // (the sessions map below); the built-in stateless legacy fallback is
-  // never invoked.
+  // Auth is checked in handleMcp before dispatching here, so a missing key
+  // gets the same 401 as the legacy leg's (a factory throw becomes a 500).
   const modernHandler = createMcpHandler(
     (ctx) => {
       const apiKey = ctx.requestInfo

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -44,7 +44,6 @@ function extractBearerToken(req: IncomingMessage): string | null {
   return token || null;
 }
 
-/** Same as `extractBearerToken`, for the modern leg's Web-standard `Request`. */
 function extractBearerTokenFromWebRequest(req: Request): string | null {
   const header = req.headers.get('authorization');
   if (!header || !header.startsWith('Bearer ')) return null;
@@ -80,10 +79,6 @@ export interface HttpTransportOptions {
  * from the Bearer token provided by the connecting client. This allows
  * remote deployment where each user authenticates with their own API key
  * instead of a single server-side key.
- *
- * Legacy clients keep the sessionful path below unchanged; modern
- * (2026-07-28) clients are stateless by protocol design, so they're routed
- * to a separate, additive `createMcpHandler` leg via `isLegacyRequest`.
  */
 export async function runHttp(
   options: ServerOptions,
@@ -98,8 +93,7 @@ export async function runHttp(
     res.end(JSON.stringify({ status: 'ok' }));
   });
 
-  // Auth is checked in handleMcp before dispatching here, so a missing key
-  // gets the same 401 as the legacy leg's (a factory throw becomes a 500).
+  // Checked in handleMcp before dispatching here — a factory throw becomes a 500, not this 401.
   const modernHandler = createMcpHandler(
     (ctx) => {
       const apiKey = ctx.requestInfo

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -116,9 +116,9 @@ export async function runHttp(
     req: IncomingMessage & { body?: unknown },
     res: ServerResponse,
   ) => {
-    const probe = await toWebRequest(req, req.body);
-    if (!(await isLegacyRequest(probe, req.body))) {
-      const apiKey = extractBearerTokenFromWebRequest(probe);
+    const webRequest = await toWebRequest(req, req.body);
+    if (!(await isLegacyRequest(webRequest, req.body))) {
+      const apiKey = extractBearerTokenFromWebRequest(webRequest);
       if (!apiKey) {
         sendJsonRpcError(
           res,

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,13 +1,21 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
-import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpExpressApp } from '@modelcontextprotocol/express';
+import {
+  NodeStreamableHTTPServerTransport,
+  toNodeHandler,
+  toWebRequest,
+} from '@modelcontextprotocol/node';
+import {
+  createMcpHandler,
+  isInitializeRequest,
+  isLegacyRequest,
+} from '@modelcontextprotocol/server';
 import { Resend } from 'resend';
 import { createMcpServer } from '../server.js';
 import type { ServerOptions } from '../types.js';
 
-const sessions: Record<string, StreamableHTTPServerTransport> = {};
+const sessions: Record<string, NodeStreamableHTTPServerTransport> = {};
 
 function sendJsonRpcError(
   res: ServerResponse,
@@ -31,6 +39,14 @@ function sendJsonRpcError(
  */
 function extractBearerToken(req: IncomingMessage): string | null {
   const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) return null;
+  const token = header.slice('Bearer '.length).trim();
+  return token || null;
+}
+
+/** Same as `extractBearerToken`, for the Web-standard `Request` the modern leg deals in. */
+function extractBearerTokenFromWebRequest(req: Request): string | null {
+  const header = req.headers.get('authorization');
   if (!header || !header.startsWith('Bearer ')) return null;
   const token = header.slice('Bearer '.length).trim();
   return token || null;
@@ -64,6 +80,12 @@ export interface HttpTransportOptions {
  * from the Bearer token provided by the connecting client. This allows
  * remote deployment where each user authenticates with their own API key
  * instead of a single server-side key.
+ *
+ * Legacy (pre-2026-07-28, `initialize`-handshake) clients are served exactly
+ * as before, via the sessionful `sessions` map below. Modern (2026-07-28)
+ * clients are stateless by protocol design — no `initialize`, no session ID
+ * — so they're served by a separate, additive `createMcpHandler` leg,
+ * dispatched per request via `isLegacyRequest`.
  */
 export async function runHttp(
   options: ServerOptions,
@@ -78,14 +100,51 @@ export async function runHttp(
     res.end(JSON.stringify({ status: 'ok' }));
   });
 
+  // The auth check happens here, before dispatching into modernHandler, so a
+  // missing key gets the same 401 shape as the legacy leg's — a factory
+  // `throw` is converted by createMcpHandler into a generic 500 instead.
+  // `legacy: 'reject'` keeps exactly one source of truth for legacy serving
+  // (the sessions map below); the built-in stateless legacy fallback is
+  // never invoked.
+  const modernHandler = createMcpHandler(
+    (ctx) => {
+      const apiKey = ctx.requestInfo
+        ? extractBearerTokenFromWebRequest(ctx.requestInfo)
+        : null;
+      if (!apiKey) {
+        throw new Error(
+          'Unauthorized: provide a Resend API key via Authorization: Bearer <key>',
+        );
+      }
+      return createMcpServer(new Resend(apiKey), options, apiKey);
+    },
+    { legacy: 'reject' },
+  );
+  const modernNodeHandler = toNodeHandler(modernHandler);
+
   // Serve the Streamable HTTP transport at both `/mcp` and the root `/` so
   // clients and proxies that target the server's root URL work identically.
   const handleMcp = async (
     req: IncomingMessage & { body?: unknown },
     res: ServerResponse,
   ) => {
+    const probe = await toWebRequest(req, req.body);
+    if (!(await isLegacyRequest(probe, req.body))) {
+      const apiKey = extractBearerTokenFromWebRequest(probe);
+      if (!apiKey) {
+        sendJsonRpcError(
+          res,
+          401,
+          'Unauthorized: provide a Resend API key via Authorization: Bearer <key>',
+        );
+        return;
+      }
+      await modernNodeHandler(req, res, req.body);
+      return;
+    }
+
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    let transport: StreamableHTTPServerTransport | undefined;
+    let transport: NodeStreamableHTTPServerTransport | undefined;
 
     if (sessionId && sessions[sessionId]) {
       transport = sessions[sessionId];
@@ -108,7 +167,7 @@ export async function runHttp(
 
       const resend = new Resend(apiKey);
 
-      transport = new StreamableHTTPServerTransport({
+      transport = new NodeStreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (sid) => {
           sessions[sid] = transport!;
@@ -159,6 +218,7 @@ export async function runHttp(
         }
         delete sessions[sid];
       }
+      await modernHandler.close().catch(() => {});
       server.close();
       process.exit(0);
     };

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,4 +1,4 @@
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import type { Resend } from 'resend';
 import { createMcpServer } from '../server.js';
 import type { ServerOptions } from '../types.js';
@@ -8,8 +8,9 @@ export async function runStdio(
   options: ServerOptions,
   apiKey: string,
 ): Promise<void> {
-  const server = createMcpServer(resend, options, apiKey);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  serveStdio(() => createMcpServer(resend, options, apiKey), {
+    legacy: 'serve',
+    onerror: (error) => console.error('stdio connection error:', error),
+  });
   console.error('Resend MCP Server running on stdio');
 }

--- a/tests/tools/contactImports.test.ts
+++ b/tests/tools/contactImports.test.ts
@@ -1,6 +1,5 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addContactImportTools } from '../../src/tools/contactImports.js';

--- a/tests/tools/editor.test.ts
+++ b/tests/tools/editor.test.ts
@@ -10,7 +10,6 @@ type ToolHandler = (
   ctx: ServerContext,
 ) => Promise<unknown>;
 
-/** Minimal fake `McpServer`; lets a test control `getClientVersion()` (the legacy path). */
 function createFakeServer(clientInfo?: { name: string; version: string }) {
   const tools = new Map<string, ToolHandler>();
   const server = {
@@ -24,7 +23,6 @@ function createFakeServer(clientInfo?: { name: string; version: string }) {
   return { server: server as unknown as McpServer, tools };
 }
 
-/** Fake `ServerContext`: omitted -> legacy (no envelope), object -> modern (envelope clientInfo). */
 function fakeCtx(clientInfo?: { name: string; version: string }) {
   return {
     mcpReq: {

--- a/tests/tools/editor.test.ts
+++ b/tests/tools/editor.test.ts
@@ -10,7 +10,7 @@ type ToolHandler = (
   ctx: ServerContext,
 ) => Promise<unknown>;
 
-/** Minimal fake `McpServer` that records registered tool handlers and lets a test control `server.server.getClientVersion()` (the legacy path). */
+/** Minimal fake `McpServer`; lets a test control `getClientVersion()` (the legacy path). */
 function createFakeServer(clientInfo?: { name: string; version: string }) {
   const tools = new Map<string, ToolHandler>();
   const server = {
@@ -24,10 +24,7 @@ function createFakeServer(clientInfo?: { name: string; version: string }) {
   return { server: server as unknown as McpServer, tools };
 }
 
-/**
- * Fake `ServerContext`: omitted -> legacy (no envelope), an object -> a
- * modern request that supplies `clientInfo` via the per-request envelope.
- */
+/** Fake `ServerContext`: omitted -> legacy (no envelope), object -> modern (envelope clientInfo). */
 function fakeCtx(clientInfo?: { name: string; version: string }) {
   return {
     mcpReq: {

--- a/tests/tools/editor.test.ts
+++ b/tests/tools/editor.test.ts
@@ -1,0 +1,128 @@
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
+import { CLIENT_INFO_META_KEY } from '@modelcontextprotocol/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardClient } from '../../src/lib/dashboard-client.js';
+import type { ResendEditorClient } from '../../src/lib/resend-editor-client.js';
+import { addEditorTools } from '../../src/tools/editor.js';
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+  ctx: ServerContext,
+) => Promise<unknown>;
+
+/** Minimal fake `McpServer` that records registered tool handlers and lets a test control `server.server.getClientVersion()` (the legacy path). */
+function createFakeServer(clientInfo?: { name: string; version: string }) {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    registerTool: (name: string, _config: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+    server: {
+      getClientVersion: () => clientInfo,
+    },
+  };
+  return { server: server as unknown as McpServer, tools };
+}
+
+/**
+ * Fake `ServerContext`: omitted -> legacy (no envelope), an object -> a
+ * modern request that supplies `clientInfo` via the per-request envelope.
+ */
+function fakeCtx(clientInfo?: { name: string; version: string }) {
+  return {
+    mcpReq: {
+      envelope: clientInfo ? { [CLIENT_INFO_META_KEY]: clientInfo } : undefined,
+    },
+  } as unknown as ServerContext;
+}
+
+function setup(clientInfo?: { name: string; version: string }) {
+  const { server, tools } = createFakeServer(clientInfo);
+  const createEditorConnection = vi.fn().mockResolvedValue({
+    apiKeyId: 'key_1',
+    room_id: 'room_1',
+  });
+  const deleteEditorConnection = vi.fn().mockResolvedValue({ ok: true });
+  const apiClient = {
+    createEditorConnection,
+    deleteEditorConnection,
+  } as unknown as ResendEditorClient;
+  const dashboard = {} as unknown as DashboardClient;
+
+  addEditorTools(server, dashboard, apiClient);
+
+  const connect = tools.get('connect-to-editor');
+  if (!connect) throw new Error('connect-to-editor not registered');
+  return { connect, createEditorConnection };
+}
+
+describe('editor agent_name resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls back to getClientVersion() on a legacy request (no envelope)', async () => {
+    const { connect, createEditorConnection } = setup({
+      name: 'legacy-client',
+      version: '0.0.0',
+    });
+
+    await connect(
+      { resource_type: 'broadcast', resource_id: 'brd_1' },
+      fakeCtx(),
+    );
+
+    expect(createEditorConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: 'legacy-client' }),
+    );
+  });
+
+  it('prefers the modern per-request envelope clientInfo over getClientVersion()', async () => {
+    const { connect, createEditorConnection } = setup({
+      name: 'legacy-client',
+      version: '0.0.0',
+    });
+
+    await connect(
+      { resource_type: 'broadcast', resource_id: 'brd_1' },
+      fakeCtx({ name: 'modern-client', version: '1.0.0' }),
+    );
+
+    expect(createEditorConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: 'modern-client' }),
+    );
+  });
+
+  it('returns undefined when neither the envelope nor getClientVersion() has a name', async () => {
+    const { connect, createEditorConnection } = setup(undefined);
+
+    await connect(
+      { resource_type: 'broadcast', resource_id: 'brd_1' },
+      fakeCtx(),
+    );
+
+    expect(createEditorConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: undefined }),
+    );
+  });
+
+  it('honors an explicit agent_name argument over both', async () => {
+    const { connect, createEditorConnection } = setup({
+      name: 'legacy-client',
+      version: '0.0.0',
+    });
+
+    await connect(
+      {
+        resource_type: 'broadcast',
+        resource_id: 'brd_1',
+        agent_name: 'My Custom Agent',
+      },
+      fakeCtx({ name: 'modern-client', version: '1.0.0' }),
+    );
+
+    expect(createEditorConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: 'My Custom Agent' }),
+    );
+  });
+});

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -1,6 +1,5 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addEmailTools } from '../../src/tools/emails.js';

--- a/tests/tools/oauthGrants.test.ts
+++ b/tests/tools/oauthGrants.test.ts
@@ -1,6 +1,5 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addOAuthGrantTools } from '../../src/tools/oauthGrants.js';

--- a/tests/tools/suppressions.test.ts
+++ b/tests/tools/suppressions.test.ts
@@ -1,6 +1,5 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addSuppressionTools } from '../../src/tools/suppressions.js';

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -1,6 +1,5 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResendEditorClient } from '../../src/lib/resend-editor-client.js';

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -164,10 +164,8 @@ describe('runHttp', () => {
   });
 });
 
-// Uses a real (but tool-less, except for one fake tool) `McpServer` — the
-// module-level mock above is a plain duck-typed `{connect}` stand-in that
-// isn't enough for the modern (2026-07-28) path, which introspects the
-// server instance itself (e.g. to install its `server/discover` handler).
+// The module-level mock's duck-typed {connect} stand-in isn't enough for the
+// modern path, which introspects the server instance itself — use a real one.
 describe('dual-era protocol support', () => {
   let runHttpWithPingTool: typeof runHttp;
 

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -164,8 +164,6 @@ describe('runHttp', () => {
   });
 });
 
-// The module-level mock's duck-typed {connect} stand-in isn't enough for the
-// modern path, which introspects the server instance itself — use a real one.
 describe('dual-era protocol support', () => {
   let runHttpWithPingTool: typeof runHttp;
 

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -1,6 +1,20 @@
 import { request } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { McpServer } from '@modelcontextprotocol/server';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { runHttp } from '../../src/transports/http.js';
 
 /**
@@ -145,6 +159,144 @@ describe('runHttp', () => {
 
     const denied = await getWithHost(port, '/health', 'other.example.com');
     expect(denied.status).toBe(403);
+
+    server.close();
+  });
+});
+
+// Uses a real (but tool-less, except for one fake tool) `McpServer` — the
+// module-level mock above is a plain duck-typed `{connect}` stand-in that
+// isn't enough for the modern (2026-07-28) path, which introspects the
+// server instance itself (e.g. to install its `server/discover` handler).
+describe('dual-era protocol support', () => {
+  let runHttpWithPingTool: typeof runHttp;
+
+  beforeAll(async () => {
+    vi.doMock('../../src/server.js', () => ({
+      createMcpServer: vi.fn(() => {
+        const server = new McpServer({ name: 'test', version: '0.0.0' });
+        server.registerTool('ping', { description: 'test tool' }, async () => ({
+          content: [{ type: 'text', text: 'pong' }],
+        }));
+        return server;
+      }),
+    }));
+    vi.resetModules();
+    ({ runHttp: runHttpWithPingTool } = await import(
+      '../../src/transports/http.js'
+    ));
+  });
+
+  afterAll(() => {
+    vi.doUnmock('../../src/server.js');
+    vi.resetModules();
+  });
+
+  async function connectedClient(
+    port: number,
+    era: 'legacy' | 'modern',
+  ): Promise<Client> {
+    const client = new Client(
+      { name: `test-client-${era}`, version: '0.0.0' },
+      era === 'modern'
+        ? { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+        : {},
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      { requestInit: { headers: { Authorization: 'Bearer re_test_key' } } },
+    );
+    await client.connect(transport);
+    return client;
+  }
+
+  it('a legacy client can list and call tools via the sessionful path', async () => {
+    const server = await runHttpWithPingTool({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+    const client = await connectedClient(port, 'legacy');
+
+    expect(client.getProtocolEra()).toBe('legacy');
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain('ping');
+    const result = await client.callTool({ name: 'ping', arguments: {} });
+    expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+
+    await client.close();
+    server.close();
+  });
+
+  it('a modern (2026-07-28) client can list and call tools via the stateless path', async () => {
+    const server = await runHttpWithPingTool({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+    const client = await connectedClient(port, 'modern');
+
+    expect(client.getProtocolEra()).toBe('modern');
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain('ping');
+    const result = await client.callTool({ name: 'ping', arguments: {} });
+    expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+
+    await client.close();
+    server.close();
+  });
+
+  it('a modern request issues no mcp-session-id (stateless)', async () => {
+    const server = await runHttpWithPingTool({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'MCP-Protocol-Version': '2026-07-28',
+        'Mcp-Method': 'tools/list',
+        Authorization: 'Bearer re_test_key',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {
+          _meta: {
+            'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+            'io.modelcontextprotocol/clientCapabilities': {},
+          },
+        },
+      }),
+    });
+
+    expect(res.headers.get('mcp-session-id')).toBeNull();
+
+    server.close();
+  });
+
+  it('a modern request without a Bearer token returns 401', async () => {
+    const server = await runHttpWithPingTool({ replierEmailAddresses: [] }, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'MCP-Protocol-Version': '2026-07-28',
+        'Mcp-Method': 'tools/list',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {
+          _meta: {
+            'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+            'io.modelcontextprotocol/clientCapabilities': {},
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(401);
 
     server.close();
   });

--- a/tests/transports/stdio.test.ts
+++ b/tests/transports/stdio.test.ts
@@ -2,19 +2,18 @@ import type { Resend } from 'resend';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runStdio } from '../../src/transports/stdio.js';
 
-const mockConnect = vi.fn().mockResolvedValue(undefined);
-
-vi.mock('../../src/server.js', () => ({
-  createMcpServer: vi.fn(() => ({
-    connect: mockConnect,
+const { mockServeStdio } = vi.hoisted(() => ({
+  mockServeStdio: vi.fn(() => ({
+    close: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
-  // biome-ignore lint/complexity/useArrowFunction: arrow functions cannot be used as constructors
-  StdioServerTransport: vi.fn(function () {
-    return {};
-  }),
+vi.mock('../../src/server.js', () => ({
+  createMcpServer: vi.fn(() => ({ mock: 'server' })),
+}));
+
+vi.mock('@modelcontextprotocol/server/stdio', () => ({
+  serveStdio: mockServeStdio,
 }));
 
 describe('runStdio', () => {
@@ -27,16 +26,28 @@ describe('runStdio', () => {
     vi.restoreAllMocks();
   });
 
-  it('creates server and connects transport', async () => {
+  it('serves with legacy: "serve" so old clients are unaffected', async () => {
+    const resend = {} as Resend;
+    await runStdio(resend, { replierEmailAddresses: [] }, 're_test_key');
+
+    expect(mockServeStdio).toHaveBeenCalledTimes(1);
+    const [, options] = mockServeStdio.mock.calls[0];
+    expect(options).toMatchObject({ legacy: 'serve' });
+  });
+
+  it('creates server via the factory passed to serveStdio', async () => {
     const resend = {} as Resend;
     await runStdio(resend, { replierEmailAddresses: [] }, 're_test_key');
     const { createMcpServer } = await import('../../src/server.js');
+
+    const [factory] = mockServeStdio.mock.calls[0];
+    factory();
+
     expect(createMcpServer).toHaveBeenCalledWith(
       resend,
       { senderEmailAddress: undefined, replierEmailAddresses: [] },
       're_test_key',
     );
-    expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
   it('passes sender and repliers to server', async () => {
@@ -50,6 +61,9 @@ describe('runStdio', () => {
       're_test_key',
     );
     const { createMcpServer } = await import('../../src/server.js');
+    const [factory] = mockServeStdio.mock.calls[0];
+    factory();
+
     expect(createMcpServer).toHaveBeenCalledWith(
       resend,
       {
@@ -60,11 +74,13 @@ describe('runStdio', () => {
     );
   });
 
-  it('rejects when server.connect rejects', async () => {
-    mockConnect.mockRejectedValueOnce(new Error('connect failed'));
+  // serveStdio is synchronous and reports connection errors via `onerror`
+  // rather than a rejected connect() promise (unlike the v1 SDK's transport).
+  it('wires connection errors to onerror instead of a rejected promise', async () => {
     const resend = {} as Resend;
-    await expect(
-      runStdio(resend, { replierEmailAddresses: [] }, 're_test_key'),
-    ).rejects.toThrow('connect failed');
+    await runStdio(resend, { replierEmailAddresses: [] }, 're_test_key');
+
+    const [, options] = mockServeStdio.mock.calls[0];
+    expect(() => options.onerror(new Error('boom'))).not.toThrow();
   });
 });

--- a/tests/transports/stdio.test.ts
+++ b/tests/transports/stdio.test.ts
@@ -74,7 +74,6 @@ describe('runStdio', () => {
     );
   });
 
-  // serveStdio reports errors via onerror, not a rejected connect() promise.
   it('wires connection errors to onerror instead of a rejected promise', async () => {
     const resend = {} as Resend;
     await runStdio(resend, { replierEmailAddresses: [] }, 're_test_key');

--- a/tests/transports/stdio.test.ts
+++ b/tests/transports/stdio.test.ts
@@ -74,8 +74,7 @@ describe('runStdio', () => {
     );
   });
 
-  // serveStdio is synchronous and reports connection errors via `onerror`
-  // rather than a rejected connect() promise (unlike the v1 SDK's transport).
+  // serveStdio reports errors via onerror, not a rejected connect() promise.
   it('wires connection errors to onerror instead of a rejected promise', async () => {
     const resend = {} as Resend;
     await runStdio(resend, { replierEmailAddresses: [] }, 're_test_key');


### PR DESCRIPTION
Migrates from MCP TypeScript SDK v1 to v2, adding support for protocol revision 2026-07-28 (stateless, per-request clients) alongside full backward compatibility for existing (`initialize`-handshake) clients on both stdio and HTTP.

Structured as 2 commits matching a natural PR split (open to splitting into a stack if preferred):

1. **Mechanical SDK v2 swap + stdio + editor.ts fix** — import-path swap across `server.ts`/`tools/*.ts`, stdio migrated to `serveStdio(factory, { legacy: 'serve' })`, and a fix for `editor.ts`'s `getAgentName()` (modern-era stdio has no `initialize` handshake to capture client identity from). Red standalone by design — `http.ts` still references the removed v1 SDK until commit 2.
2. **HTTP modern leg + v3.0.0** — additive `createMcpHandler` dispatch via `isLegacyRequest`, dual-era integration test, version bump (breaking: `createMcpServer`'s exported type now comes from `@modelcontextprotocol/server`), CHANGELOG, and a corrected README claim.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` / `pnpm test` — 149/149
- [x] Manual smoke test of the built `dist/index.js`: legacy HTTP handshake, modern stateless per-request `tools/list` (confirmed no `mcp-session-id` on the response), and stdio