### PR TITLE
chore: use the API timestamp format in test fixtures

### DIFF
--- a/tests/tools/contactImports.test.ts
+++ b/tests/tools/contactImports.test.ts
@@ -140,8 +140,8 @@ describe('get-contact-import', () => {
         object: 'contact_import',
         id: 'imp_1',
         status: 'completed',
-        created_at: '2026-01-01T00:00:00Z',
-        completed_at: '2026-01-01T00:01:00Z',
+        created_at: '2026-01-01 00:00:00+00',
+        completed_at: '2026-01-01 00:01:00+00',
         counts: { total: 5, created: 3, updated: 1, skipped: 1, failed: 0 },
       },
     });
@@ -154,7 +154,7 @@ describe('get-contact-import', () => {
     const text = textOf(result as never);
     expect(text).toContain('Status: completed');
     expect(text).toContain('Created: 3');
-    expect(text).toContain('Completed at: 2026-01-01T00:01:00Z');
+    expect(text).toContain('Completed at: 2026-01-01 00:01:00+00');
   });
 
   it('omits completed_at when null', async () => {
@@ -163,7 +163,7 @@ describe('get-contact-import', () => {
         object: 'contact_import',
         id: 'imp_1',
         status: 'in_progress',
-        created_at: '2026-01-01T00:00:00Z',
+        created_at: '2026-01-01 00:00:00+00',
         completed_at: null,
         counts: { total: 0, created: 0, updated: 0, skipped: 0, failed: 0 },
       },
@@ -191,8 +191,8 @@ describe('list-contact-imports', () => {
             object: 'contact_import',
             id: 'imp_1',
             status: 'completed',
-            created_at: '2026-01-01T00:00:00Z',
-            completed_at: '2026-01-01T00:01:00Z',
+            created_at: '2026-01-01 00:00:00+00',
+            completed_at: '2026-01-01 00:01:00+00',
             counts: { total: 1, created: 1, updated: 0, skipped: 0, failed: 0 },
           },
         ],

--- a/tests/tools/oauthGrants.test.ts
+++ b/tests/tools/oauthGrants.test.ts
@@ -35,7 +35,7 @@ const grant = {
   id: 'grant_1',
   client_id: 'client_1',
   scopes: ['emails:send'],
-  created_at: '2026-01-01T00:00:00.000Z',
+  created_at: '2026-01-01 00:00:00+00',
   revoked_at: null,
   revoked_reason: null,
   client: { name: 'Resend CLI', logo_uri: null },
@@ -68,7 +68,7 @@ describe('list-oauth-grants', () => {
             ...grant,
             id: 'grant_2',
             scopes: ['emails:send', 'domains:read'],
-            revoked_at: '2026-01-02T00:00:00.000Z',
+            revoked_at: '2026-01-02 00:00:00+00',
             revoked_reason: 'revoked_from_api',
           },
         ],
@@ -90,7 +90,7 @@ describe('list-oauth-grants', () => {
     expect(text).toContain('App: Resend CLI');
     expect(text).toContain('emails:send, domains:read');
     expect(text).toContain('active');
-    expect(text).toContain('revoked (2026-01-02T00:00:00.000Z)');
+    expect(text).toContain('revoked (2026-01-02 00:00:00+00)');
   });
 
   it('forwards the limit to the SDK', async () => {

--- a/tests/tools/suppressions.test.ts
+++ b/tests/tools/suppressions.test.ts
@@ -47,7 +47,7 @@ const entry = {
   email: 'a@b.com',
   origin: 'bounce',
   source_id: 'em_1',
-  created_at: '2026-01-01T00:00:00Z',
+  created_at: '2026-01-01 00:00:00+00',
 };
 
 describe('suppression tools', () => {
@@ -209,7 +209,7 @@ describe('get-suppression', () => {
     expect(text).toContain('Email: a@b.com');
     expect(text).toContain('ID: sup_1');
     expect(text).toContain('Origin: bounce');
-    expect(text).toContain('Created at: 2026-01-01T00:00:00Z');
+    expect(text).toContain('Created at: 2026-01-01 00:00:00+00');
   });
 });
 


### PR DESCRIPTION
## What

The API returns timestamps in Postgres text format: `YYYY-MM-DD HH:MM:SS[.ffffff]+00` (for example `2023-10-06 23:47:56.678+00`). The mock responses in the tool tests showed ISO 8601 for response fields. This PR makes them match the real API output.

- Convert 11 fixture and assertion lines in `contactImports.test.ts`, `oauthGrants.test.ts`, and `suppressions.test.ts`.

## What stays ISO 8601 on purpose

- The `revoke-oauth-grant` mock. The DELETE `/oauth/grants/{id}` endpoint returns ISO.
- The `scheduledAt` tool input descriptions. The API accepts ISO there.

## Why

The tools render these values verbatim to MCP clients. The mocks taught the tests a format the API never emits. Same change as the hosted service (resend-monorepo#7959) and the SDK-wide fixture sweep.

## Verification

- `vitest run`: 140 passed.
- `biome check .`: clean.
- `tsc` build: clean.