### PR TITLE
feat(broadcasts): add cancel-broadcast tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Received Emails**: List and read inbound emails. List and download received email attachments.
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.
-- **Broadcasts**: Create, send, list, get, update, and remove broadcast campaigns. Supports scheduling, personalization placeholders, and preview text.
+- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. Supports scheduling, personalization placeholders, and preview text.
 - **Automations**: Create, list, get, update, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.18.0",
+    "resend": "6.19.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.18.0
-        version: 6.18.0
+        specifier: 6.19.0
+        version: 6.19.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.18.0:
-    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
+  resend@6.19.0:
+    resolution: {integrity: sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.18.0:
+  resend@6.19.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -366,6 +366,43 @@ export function addBroadcastTools(
   );
 
   server.registerTool(
+    'cancel-broadcast',
+    {
+      title: 'Cancel Broadcast',
+      description: `**Purpose:** Cancel a queued or scheduled broadcast by ID or Resend dashboard URL, without removing it. Cancelling a queued broadcast stops it mid-send (emails already sent are not affected). Cancelling a scheduled broadcast reverts it to draft.
+
+**NOT for:** Removing a broadcast entirely (use remove-broadcast). Draft and sent broadcasts cannot be cancelled — sent broadcasts are immutable, and drafts have nothing to cancel.
+
+**When to use:** User wants to "stop", "cancel", or "pause" a broadcast that is currently sending or scheduled to send.`,
+      inputSchema: {
+        broadcastId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+          ),
+      },
+    },
+    async ({ broadcastId: rawBroadcastId }) => {
+      const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
+      const response = await resend.broadcasts.cancel(broadcastId);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to cancel broadcast: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: 'text', text: 'Broadcast cancelled successfully.' },
+          { type: 'text', text: `ID: ${response.data.id}` },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     'remove-broadcast',
     {
       title: 'Remove Broadcast',


### PR DESCRIPTION
## Summary
- Adds a `cancel-broadcast` MCP tool, calling `resend.broadcasts.cancel(id)` to cancel a queued or scheduled broadcast without removing it. Mirrors `remove-broadcast`'s structure.
- Bumps the `resend` dependency to `6.19.0`, the first published version with `broadcasts.cancel()`.
- Updates the README's Broadcasts capability bullet.

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059 / #1064, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250, resend/resend-ruby#216, resend/resend-rust#91, resend/resend-dotnet#136, resend/resend-cli#359.

## Test plan
- [x] `vitest run` — 149/149 passing
- [x] `tsc --noEmit` — clean
- [x] `biome check src/tools/broadcasts.ts` — clean

Note: there's no existing `broadcasts.test.ts` in this repo (broadcasts tools currently have zero dedicated test coverage), so this PR doesn't introduce one either — happy to add coverage for the whole file in a follow-up if that's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)