### PR TITLE
feat(automations): add duplicate-automation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.
 - **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. Supports scheduling, personalization placeholders, and preview text.
-- **Automations**: Create, list, get, update, and remove automations. Review the runs of an automation.
+- **Automations**: Create, list, get, update, duplicate, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.
 - **Segments**: Create, list, get, and remove audience segments.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.19.0",
+    "resend": "6.21.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.19.0
-        version: 6.19.0
+        specifier: 6.21.0
+        version: 6.21.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.19.0:
-    resolution: {integrity: sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==}
+  resend@6.21.0:
+    resolution: {integrity: sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.19.0:
+  resend@6.21.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -1,5 +1,25 @@
 const SUPPORTED_RESOURCES = ['broadcasts', 'templates', 'automations'];
 
+const DEFAULT_DASHBOARD_HOSTS = ['resend.com', 'www.resend.com'];
+
+function allowedDashboardHosts(): string[] {
+  const configured = process.env.RESEND_DASHBOARD_URL;
+  if (!configured) return DEFAULT_DASHBOARD_HOSTS;
+
+  let hostname: string;
+  try {
+    hostname = new URL(configured).hostname;
+  } catch {
+    return DEFAULT_DASHBOARD_HOSTS;
+  }
+
+  if (DEFAULT_DASHBOARD_HOSTS.includes(hostname)) {
+    return DEFAULT_DASHBOARD_HOSTS;
+  }
+
+  return [...DEFAULT_DASHBOARD_HOSTS, hostname];
+}
+
 /**
  * Extracts a resource ID from a Resend dashboard URL.
  *
@@ -7,6 +27,11 @@ const SUPPORTED_RESOURCES = ['broadcasts', 'templates', 'automations'];
  *   https://resend.com/broadcasts/<id>
  *   https://resend.com/templates/<id>
  *   https://resend.com/automations/<id>
+ *
+ * Production hosts are always accepted. A server pointed at another stack also
+ * accepts its own dashboard host from `RESEND_DASHBOARD_URL`, the same env var
+ * `DashboardClient` reads, so a URL copied from the dashboard the client is
+ * actually using resolves. Every other host is still rejected.
  *
  * If the input is not a URL, it is returned as-is (assumed to be a raw ID).
  * If the input is a URL but cannot be resolved to an ID, an error is thrown.
@@ -34,10 +59,10 @@ export function extractIdFromUrl(
     );
   }
 
-  // Only handle resend.com URLs
-  if (url.hostname !== 'resend.com' && url.hostname !== 'www.resend.com') {
+  const dashboardHosts = allowedDashboardHosts();
+  if (!dashboardHosts.includes(url.hostname)) {
     throw new Error(
-      `Unrecognized URL host "${url.hostname}". Expected a resend.com URL (e.g. https://resend.com/${expectedResource ?? 'broadcasts'}/<id>) or a raw resource ID.`,
+      `Unrecognized URL host "${url.hostname}". Expected a dashboard URL on ${dashboardHosts.join(' or ')} (e.g. https://resend.com/${expectedResource ?? 'broadcasts'}/<id>) or a raw resource ID.`,
     );
   }
 

--- a/src/tools/automations.ts
+++ b/src/tools/automations.ts
@@ -411,6 +411,45 @@ ${WORKFLOW_GUIDANCE}`,
   );
 
   server.registerTool(
+    'duplicate-automation',
+    {
+      title: 'Duplicate Automation',
+      description:
+        'Duplicate an existing automation by ID or Resend dashboard URL. Creates a copy with its own ID, including the steps and connections of the original. Use this when the user wants a new automation based on one they already have, instead of rebuilding the workflow from scratch. Use update-automation on the new ID to rename it or change its workflow.',
+      inputSchema: {
+        id: z
+          .string()
+          .nonempty()
+          .describe(
+            'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>) of the automation to duplicate',
+          ),
+      },
+    },
+    async ({ id: rawId }) => {
+      const id = extractIdFromUrl(rawId, 'automations');
+      const response = await resend.automations.duplicate(id);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to duplicate automation: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const newId = response.data.id;
+      return {
+        content: [
+          { type: 'text', text: 'Automation duplicated successfully.' },
+          { type: 'text', text: `New automation ID: ${newId}` },
+          {
+            type: 'text',
+            text: `Preview: https://resend.com/automations/${newId}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     'remove-automation',
     {
       title: 'Remove Automation',

--- a/tests/lib/url-parser.test.ts
+++ b/tests/lib/url-parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { extractIdFromUrl } from '../../src/lib/url-parser.js';
 
 describe('extractIdFromUrl', () => {
@@ -46,6 +46,52 @@ describe('extractIdFromUrl', () => {
     expect(() =>
       extractIdFromUrl('https://example.com/broadcasts/abc-123', 'broadcasts'),
     ).toThrow(/unrecognized URL host/i);
+  });
+
+  describe('with a non-production RESEND_DASHBOARD_URL', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('accepts a URL on the configured dashboard host', () => {
+      vi.stubEnv('RESEND_DASHBOARD_URL', 'https://resend-staging.com');
+      expect(
+        extractIdFromUrl(
+          'https://resend-staging.com/automations/auto-789',
+          'automations',
+        ),
+      ).toBe('auto-789');
+    });
+
+    it('still accepts production URLs', () => {
+      vi.stubEnv('RESEND_DASHBOARD_URL', 'https://resend-staging.com');
+      expect(
+        extractIdFromUrl(
+          'https://resend.com/automations/auto-789',
+          'automations',
+        ),
+      ).toBe('auto-789');
+    });
+
+    it('still rejects every other host', () => {
+      vi.stubEnv('RESEND_DASHBOARD_URL', 'https://resend-staging.com');
+      expect(() =>
+        extractIdFromUrl(
+          'https://example.com/automations/auto-789',
+          'automations',
+        ),
+      ).toThrow(/unrecognized URL host/i);
+    });
+
+    it('falls back to production hosts when the env value is not a URL', () => {
+      vi.stubEnv('RESEND_DASHBOARD_URL', 'not-a-url');
+      expect(() =>
+        extractIdFromUrl(
+          'https://resend-staging.com/automations/auto-789',
+          'automations',
+        ),
+      ).toThrow(/unrecognized URL host/i);
+    });
   });
 
   it('throws for URLs with insufficient path segments', () => {


### PR DESCRIPTION
Adds a `duplicate-automation` tool for the new `POST /automations/:id/duplicate` endpoint.

Same shape as `duplicate-template`: accepts an ID or a dashboard URL via `extractIdFromUrl`, returns the new ID plus a preview link. The description tells the model to use this instead of rebuilding a workflow from scratch, and to follow up with `update-automation` to rename the copy.

### The SDK bump

`resend` was pinned at 6.19.0, which does not have `automations.duplicate` — it shipped in 6.20.0. Bumped to 6.21.0, the current latest. Without this the tool does not compile. Same file set as #206 (`cancel-broadcast`).

### Version

2.13.0 → 2.14.0, minor for a new tool. 2.13.0 is already on npm, bumped by #207.

### Third commit: non-production dashboard URLs were rejected

Review on the hosted MCP (resend/resend-monorepo#8815) caught that `extractIdFromUrl` hardcodes `resend.com`/`www.resend.com`. This repo has the same defect and it is reachable here too: `DashboardClient` already follows `RESEND_DASHBOARD_URL` for the editor/TipTap tooling, so a server pointed at another Resend stack accepts that dashboard everywhere except the URL parser, which rejects it:

```
Unrecognized URL host "resend-staging.com". Expected a resend.com URL […]
```

Fixed in the parser, not the call site — it is shared by every tool that takes an ID or URL, and predates this PR. Production hosts are always accepted; the `RESEND_DASHBOARD_URL` host is accepted too. Host validation is retained: every other host still throws, including when the env value is not a parseable URL. Four regression tests cover accept-configured, still-accept-production, still-reject-others, and the bad-env fallback.

The same fix, with the same tests, is in resend/resend-monorepo#8815 so the two MCPs do not drift.

### Verification

- `pnpm build` and `pnpm lint` clean (the 3 remaining warnings are pre-existing, in `transports`)
- `pnpm test` — 153 passed (149 before the parser tests)
- Ran a throwaway test that stood up the server over `InMemoryTransport`, confirmed `duplicate-automation` appears in `listTools`, and called it with `https://resend.com/automations/abc-123` — the URL parses to `abc-123` and reaches `resend.automations.duplicate`. Not committed; there is no `tests/tools/automations.test.ts` to add it to.

Docs side: resend/resend-docs#1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)