### PR TITLE
chore: bump version to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump version to 2.15.0. Minor release covering #210 (update-api-key tool) and #211 (share-email tool).