### PR TITLE
feat: add list-broadcast-clicked-links tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Received Emails**: List and read inbound emails. List and download received email attachments.
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.
-- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. Supports scheduling, personalization placeholders, and preview text.
+- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. List a broadcast's clicked links. Supports scheduling, personalization placeholders, and preview text.
 - **Automations**: Create, list, get, update, duplicate, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.21.0",
+    "resend": "6.22.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.21.0
-        version: 6.21.0
+        specifier: 6.22.0
+        version: 6.22.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.21.0:
-    resolution: {integrity: sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==}
+  resend@6.22.0:
+    resolution: {integrity: sha512-dP1jyl0n1Dx7GYDb0bcsbv9Yx0oBRLhUtSyNFRIOsSzV9MvCVbua/3WP6YUP2JptAU5BciEWGInV+hFjUuYLUw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.21.0:
+  resend@6.22.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -787,12 +787,14 @@ export function addBroadcastTools(
           ),
         after: z
           .string()
+          .min(1)
           .optional()
           .describe(
             'Cursor after which to retrieve more (for forward pagination). Cannot be used with "before".',
           ),
         before: z
           .string()
+          .min(1)
           .optional()
           .describe(
             'Cursor before which to retrieve more (for backward pagination). Cannot be used with "after".',
@@ -846,15 +848,17 @@ export function addBroadcastTools(
             type: 'text',
             text: `Found ${links.length} clicked link${links.length === 1 ? '' : 's'}:`,
           },
-          ...links.map(({ url, clicks, unique_clicks }) => ({
+          ...links.map(({ id, url, clicks, unique_clicks }) => ({
             type: 'text' as const,
-            text: `URL: ${url}\nClicks: ${clicks}\nUnique clicks: ${unique_clicks}`,
+            text: `ID: ${id}\nURL: ${url}\nClicks: ${clicks}\nUnique clicks: ${unique_clicks}`,
           })),
           ...(hasMore
             ? [
                 {
                   type: 'text' as const,
-                  text: 'There are more clicked links available. Use the "after" parameter with the last cursor to retrieve more.',
+                  text: before
+                    ? 'There are more clicked links available. Use the "before" parameter with the first cursor to retrieve more.'
+                    : 'There are more clicked links available. Use the "after" parameter with the last cursor to retrieve more.',
                 },
               ]
             : []),

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -757,4 +757,109 @@ export function addBroadcastTools(
       };
     },
   );
+
+  server.registerTool(
+    'list-broadcast-clicked-links',
+    {
+      title: 'List Broadcast Clicked Links',
+      annotations: { readOnlyHint: true },
+      description: `**Purpose:** List the links clicked in a broadcast, ranked by total clicks.
+
+**Returns:** For each link: url, clicks (total), unique_clicks. Use pagination (limit, after/before) for large lists.
+
+**When to use:**
+- User asks "what links were clicked in this broadcast?", "top clicked links", "click breakdown for this campaign"
+- Use get-broadcast for overall broadcast details; use this for per-link click data.`,
+      inputSchema: {
+        broadcastId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+          ),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe(
+            'Number of links to retrieve. Default: 20, Max: 100, Min: 1',
+          ),
+        after: z
+          .string()
+          .optional()
+          .describe(
+            'Cursor after which to retrieve more (for forward pagination). Cannot be used with "before".',
+          ),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            'Cursor before which to retrieve more (for backward pagination). Cannot be used with "after".',
+          ),
+      },
+    },
+    async ({ broadcastId: rawBroadcastId, limit, after, before }) => {
+      if (after && before) {
+        throw new Error(
+          'Cannot use both "after" and "before" parameters. Use only one for pagination.',
+        );
+      }
+
+      const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
+      const paginationOptions = after
+        ? { limit, after }
+        : before
+          ? { limit, before }
+          : limit !== undefined
+            ? { limit }
+            : undefined;
+
+      const response = await resend.broadcasts.clickedLinks(
+        broadcastId,
+        paginationOptions,
+      );
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list broadcast clicked links: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const links = response.data?.data ?? [];
+      const hasMore = response.data?.has_more ?? false;
+
+      if (links.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'No clicked links found for this broadcast.',
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${links.length} clicked link${links.length === 1 ? '' : 's'}:`,
+          },
+          ...links.map(({ url, clicks, unique_clicks }) => ({
+            type: 'text' as const,
+            text: `URL: ${url}\nClicks: ${clicks}\nUnique clicks: ${unique_clicks}`,
+          })),
+          ...(hasMore
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more clicked links available. Use the "after" parameter with the last cursor to retrieve more.',
+                },
+              ]
+            : []),
+        ],
+      };
+    },
+  );
 }

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -765,7 +765,7 @@ export function addBroadcastTools(
       annotations: { readOnlyHint: true },
       description: `**Purpose:** List the links clicked in a broadcast, ranked by total clicks.
 
-**Returns:** For each link: url, clicks (total), unique_clicks. Use pagination (limit, after/before) for large lists.
+**Returns:** For each link: id (opaque pagination cursor for that row, not an entity id), url, clicks (total), unique_clicks. Use pagination (limit, after/before) for large lists.
 
 **When to use:**
 - User asks "what links were clicked in this broadcast?", "top clicked links", "click breakdown for this campaign"
@@ -787,6 +787,7 @@ export function addBroadcastTools(
           ),
         after: z
           .string()
+          .trim()
           .min(1)
           .optional()
           .describe(
@@ -794,6 +795,7 @@ export function addBroadcastTools(
           ),
         before: z
           .string()
+          .trim()
           .min(1)
           .optional()
           .describe(

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -99,6 +99,74 @@ describe('list-broadcast-clicked-links', () => {
     });
   });
 
+  it('passes before for backward pagination', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1', limit: 5, before: 'cursor-1' },
+    });
+
+    expect(clickedLinks).toHaveBeenCalledWith('bc_1', {
+      limit: 5,
+      before: 'cursor-1',
+    });
+  });
+
+  it('hints at "after" for more results on a forward page', async () => {
+    clickedLinks.mockResolvedValueOnce({
+      data: {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: 'b2Zmc2V0OjA',
+            url: 'https://resend.com/pricing',
+            clicks: 42,
+            unique_clicks: 30,
+          },
+        ],
+      },
+      error: null,
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1', after: 'cursor-1' },
+    });
+
+    expect(textOf(result as never)).toContain('ID: b2Zmc2V0OjA');
+    expect(textOf(result as never)).toContain(
+      'Use the "after" parameter with the last cursor',
+    );
+  });
+
+  it('hints at "before" for more results on a backward page', async () => {
+    clickedLinks.mockResolvedValueOnce({
+      data: {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: 'b2Zmc2V0OjA',
+            url: 'https://resend.com/pricing',
+            clicks: 42,
+            unique_clicks: 30,
+          },
+        ],
+      },
+      error: null,
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1', before: 'cursor-1' },
+    });
+
+    expect(textOf(result as never)).toContain(
+      'Use the "before" parameter with the first cursor',
+    );
+  });
+
   it('rejects both after and before', async () => {
     const client = await makeClient();
     const result = await client.callTool({

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -1,0 +1,145 @@
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addBroadcastTools } from '../../src/tools/broadcasts.js';
+
+const clickedLinks = vi.fn();
+
+const resend = {
+  broadcasts: { clickedLinks },
+} as unknown as Resend;
+
+const apiClient = {} as never;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addBroadcastTools(server, resend, apiClient, {
+    replierEmailAddresses: [],
+    withEditorSession: (_conn, fn) => fn(),
+  });
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+describe('list-broadcast-clicked-links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clickedLinks.mockResolvedValue({
+      data: {
+        object: 'list',
+        has_more: false,
+        data: [
+          {
+            id: 'b2Zmc2V0OjA',
+            url: 'https://resend.com/pricing',
+            clicks: 42,
+            unique_clicks: 30,
+          },
+        ],
+      },
+      error: null,
+    });
+  });
+
+  it('registers the tool as read-only', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === 'list-broadcast-clicked-links');
+    expect(tool).toBeDefined();
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('lists clicked links for a broadcast', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1' },
+    });
+
+    expect(clickedLinks).toHaveBeenCalledWith('bc_1', undefined);
+    expect(textOf(result as never)).toContain('https://resend.com/pricing');
+    expect(textOf(result as never)).toContain('Clicks: 42');
+    expect(textOf(result as never)).toContain('Unique clicks: 30');
+  });
+
+  it('extracts the id from a dashboard URL', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'https://resend.com/broadcasts/bc_1' },
+    });
+
+    expect(clickedLinks).toHaveBeenCalledWith('bc_1', undefined);
+  });
+
+  it('passes pagination options', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1', limit: 5, after: 'cursor-1' },
+    });
+
+    expect(clickedLinks).toHaveBeenCalledWith('bc_1', {
+      limit: 5,
+      after: 'cursor-1',
+    });
+  });
+
+  it('rejects both after and before', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1', after: 'a', before: 'b' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      'Cannot use both "after" and "before"',
+    );
+  });
+
+  it('reports when there are no clicked links', async () => {
+    clickedLinks.mockResolvedValueOnce({
+      data: { object: 'list', has_more: false, data: [] },
+      error: null,
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1' },
+    });
+
+    expect(textOf(result as never)).toContain('No clicked links found');
+  });
+
+  it('surfaces SDK errors', async () => {
+    clickedLinks.mockResolvedValueOnce({
+      data: null,
+      error: { name: 'not_found', message: 'Broadcast not found' },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-clicked-links',
+      arguments: { broadcastId: 'bc_1' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      'Failed to list broadcast clicked links',
+    );
+  });
+});


### PR DESCRIPTION
Adds `list-broadcast-clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077