### PR TITLE
feat(broadcasts): add list-broadcast-recipients tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Received Emails**: List and read inbound emails. List and download received email attachments.
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.
-- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. List a broadcast's clicked links. Supports scheduling, personalization placeholders, and preview text.
+- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. List a broadcast's clicked links, and its recipients by event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed). Supports scheduling, personalization placeholders, and preview text.
 - **Automations**: Create, list, get, update, duplicate, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -946,6 +946,9 @@ export function addBroadcastTools(
           'Cannot use both "after" and "before" parameters. Use only one for pagination.',
         );
       }
+      if (bounceType !== undefined && type !== 'bounced') {
+        throw new Error('"bounceType" is only valid when type is "bounced".');
+      }
 
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
 
@@ -997,6 +1000,7 @@ export function addBroadcastTools(
                 `Count: ${recipient.count}`,
               'bounce_type' in recipient &&
                 recipient.bounce_type !== undefined &&
+                recipient.bounce_type !== null &&
                 `Bounce type: ${recipient.bounce_type}`,
               'clicked_links' in recipient &&
                 recipient.clicked_links !== undefined &&
@@ -1009,7 +1013,9 @@ export function addBroadcastTools(
             ? [
                 {
                   type: 'text' as const,
-                  text: 'There are more recipients available. Use the "after" parameter with the last ID to retrieve more.',
+                  text: before
+                    ? 'There are more recipients available. Use the "before" parameter with the first ID shown above to retrieve earlier recipients.'
+                    : 'There are more recipients available. Use the "after" parameter with the last ID shown above to retrieve more.',
                 },
               ]
             : []),

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -868,4 +868,153 @@ export function addBroadcastTools(
       };
     },
   );
+
+  server.registerTool(
+    'list-broadcast-recipients',
+    {
+      title: 'List Broadcast Recipients',
+      annotations: { readOnlyHint: true },
+      description: `**Purpose:** List the individual recipients of a broadcast for a given event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed).
+
+**NOT for:** Listing broadcasts themselves (use list-broadcasts). Not for aggregate/summary stats — this returns per-recipient rows, one per contact per event type.
+
+**Returns:** For each recipient: email, id (opaque pagination cursor), contact_id (when known). Also includes count for "opened"/"clicked", bounce_type for "bounced", and clicked_links (url + click count) for "clicked". Use pagination (limit, after/before) for large lists.
+
+**When to use:** User asks "who opened this broadcast?", "who bounced?", "who clicked this link?", "who unsubscribed from this campaign?", or wants the list of contacts behind a specific broadcast engagement metric. Use get-broadcast first if you need the broadcast ID from a name.`,
+      inputSchema: {
+        broadcastId: z
+          .string()
+          .nonempty()
+          .describe(
+            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+          ),
+        type: z
+          .enum([
+            'sent',
+            'delivered',
+            'opened',
+            'clicked',
+            'bounced',
+            'complained',
+            'unsubscribed',
+            'suppressed',
+          ])
+          .describe('Recipient event type to list recipients for.'),
+        email: z
+          .string()
+          .optional()
+          .describe('Filter recipients by a substring of their email address.'),
+        bounceType: z
+          .enum(['permanent', 'transient', 'undetermined'])
+          .optional()
+          .describe(
+            'Filter by bounce type. Only meaningful when "type" is "bounced".',
+          ),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe(
+            'Number of recipients to retrieve. Default: 20, Max: 100, Min: 1',
+          ),
+        after: z
+          .string()
+          .optional()
+          .describe(
+            'Recipient ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+          ),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            'Recipient ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+          ),
+      },
+    },
+    async ({
+      broadcastId: rawBroadcastId,
+      type,
+      email,
+      bounceType,
+      limit,
+      after,
+      before,
+    }) => {
+      if (after && before) {
+        throw new Error(
+          'Cannot use both "after" and "before" parameters. Use only one for pagination.',
+        );
+      }
+
+      const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
+
+      const paginationOptions = after
+        ? { limit, after }
+        : before
+          ? { limit, before }
+          : limit !== undefined
+            ? { limit }
+            : {};
+
+      const response = await resend.broadcasts.recipients(broadcastId, {
+        ...paginationOptions,
+        type,
+        ...(email !== undefined && { email }),
+        ...(bounceType !== undefined && { bounceType }),
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list broadcast recipients: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const recipients = response.data?.data ?? [];
+      const hasMore = response.data?.has_more ?? false;
+
+      if (recipients.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No recipients found.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${recipients.length} recipient${recipients.length === 1 ? '' : 's'}:`,
+          },
+          ...recipients.map((recipient) => ({
+            type: 'text' as const,
+            text: [
+              `Email: ${recipient.email}`,
+              `ID: ${recipient.id}`,
+              recipient.contact_id !== null &&
+                `Contact ID: ${recipient.contact_id}`,
+              'count' in recipient &&
+                recipient.count !== undefined &&
+                `Count: ${recipient.count}`,
+              'bounce_type' in recipient &&
+                recipient.bounce_type !== undefined &&
+                `Bounce type: ${recipient.bounce_type}`,
+              'clicked_links' in recipient &&
+                recipient.clicked_links !== undefined &&
+                `Clicked links: ${recipient.clicked_links.map((link) => `${link.url} (${link.clicks} click${link.clicks === 1 ? '' : 's'})`).join(', ')}`,
+            ]
+              .filter(Boolean)
+              .join('\n'),
+          })),
+          ...(hasMore
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more recipients available. Use the "after" parameter with the last ID to retrieve more.',
+                },
+              ]
+            : []),
+        ],
+      };
+    },
+  );
 }

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -920,12 +920,14 @@ export function addBroadcastTools(
           ),
         after: z
           .string()
+          .nonempty()
           .optional()
           .describe(
             'Recipient ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
           ),
         before: z
           .string()
+          .nonempty()
           .optional()
           .describe(
             'Recipient ID before which to retrieve more (for backward pagination). Cannot be used with "after".',

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -2,21 +2,23 @@ import { Client } from '@modelcontextprotocol/client';
 import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResendEditorClient } from '../../src/lib/resend-editor-client.js';
 import { addBroadcastTools } from '../../src/tools/broadcasts.js';
 
 const clickedLinks = vi.fn();
+const recipients = vi.fn();
 
 const resend = {
-  broadcasts: { clickedLinks },
+  broadcasts: { clickedLinks, recipients },
 } as unknown as Resend;
 
-const apiClient = {} as never;
+const apiClient = {} as ResendEditorClient;
 
 async function makeClient() {
   const server = new McpServer({ name: 'test', version: '0.0.0' });
   addBroadcastTools(server, resend, apiClient, {
     replierEmailAddresses: [],
-    withEditorSession: (_conn, fn) => fn(),
+    withEditorSession: async (_conn, fn) => fn(),
   });
   const client = new Client({ name: 'test-client', version: '0.0.0' });
   const [clientTransport, serverTransport] =
@@ -208,6 +210,240 @@ describe('list-broadcast-clicked-links', () => {
     expect(result.isError).toBe(true);
     expect(textOf(result as never)).toContain(
       'Failed to list broadcast clicked links',
+    );
+  });
+});
+
+describe('list-broadcast-recipients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requires a type and passes it through to the SDK', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'opened' },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', { type: 'opened' });
+  });
+
+  it('extracts the broadcast ID from a dashboard URL', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: {
+        broadcastId: 'https://resend.com/broadcasts/bc_1',
+        type: 'sent',
+      },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', { type: 'sent' });
+  });
+
+  it('formats a plain recipient row', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [{ id: 'rcp_1', contact_id: 'con_1', email: 'a@b.com' }],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'delivered' },
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('Found 1 recipient:');
+    expect(text).toContain('Email: a@b.com');
+    expect(text).toContain('ID: rcp_1');
+    expect(text).toContain('Contact ID: con_1');
+  });
+
+  it('omits contact ID when null', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [{ id: 'rcp_1', contact_id: null, email: 'a@b.com' }],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent' },
+    });
+    expect(textOf(result as never)).not.toContain('Contact ID');
+  });
+
+  it('includes the count for opened recipients', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [{ id: 'rcp_1', contact_id: null, email: 'a@b.com', count: 3 }],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'opened' },
+    });
+    expect(textOf(result as never)).toContain('Count: 3');
+  });
+
+  it('includes bounce type for bounced recipients', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [
+          {
+            id: 'rcp_1',
+            contact_id: null,
+            email: 'a@b.com',
+            bounce_type: 'permanent',
+          },
+        ],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: {
+        broadcastId: 'bc_1',
+        type: 'bounced',
+        bounceType: 'permanent',
+      },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', {
+      type: 'bounced',
+      bounceType: 'permanent',
+    });
+    expect(textOf(result as never)).toContain('Bounce type: permanent');
+  });
+
+  it('includes clicked links for clicked recipients', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [
+          {
+            id: 'rcp_1',
+            contact_id: null,
+            email: 'a@b.com',
+            count: 2,
+            clicked_links: [{ url: 'https://example.com', clicks: 2 }],
+          },
+        ],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'clicked' },
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('Count: 2');
+    expect(text).toContain('Clicked links: https://example.com (2 clicks)');
+  });
+
+  it('forwards the email filter', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent', email: 'a@b.com' },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', {
+      type: 'sent',
+      email: 'a@b.com',
+    });
+  });
+
+  it('forwards the after cursor with limit', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: {
+        broadcastId: 'bc_1',
+        type: 'sent',
+        after: 'rcp_1',
+        limit: 10,
+      },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', {
+      limit: 10,
+      after: 'rcp_1',
+      type: 'sent',
+    });
+  });
+
+  it('forwards the before cursor', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent', before: 'rcp_9' },
+    });
+    expect(recipients).toHaveBeenCalledWith('bc_1', {
+      before: 'rcp_9',
+      type: 'sent',
+    });
+  });
+
+  it('rejects using both after and before', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: {
+        broadcastId: 'bc_1',
+        type: 'sent',
+        after: 'a',
+        before: 'b',
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Cannot use both');
+    expect(recipients).not.toHaveBeenCalled();
+  });
+
+  it('reports when none are found', async () => {
+    recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent' },
+    });
+    expect(textOf(result as never)).toContain('No recipients found.');
+  });
+
+  it('shows a has_more hint', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: true,
+        data: [{ id: 'rcp_1', contact_id: null, email: 'a@b.com' }],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent' },
+    });
+    expect(textOf(result as never)).toContain(
+      'There are more recipients available',
+    );
+  });
+
+  it('surfaces SDK errors', async () => {
+    recipients.mockResolvedValueOnce({ error: { message: 'not found' } });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_404', type: 'sent' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      'Failed to list broadcast recipients',
     );
   });
 });

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -446,6 +446,26 @@ describe('list-broadcast-recipients', () => {
     expect(recipients).not.toHaveBeenCalled();
   });
 
+  it('rejects an empty-string after cursor', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent', after: '' },
+    });
+    expect(result.isError).toBe(true);
+    expect(recipients).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty-string before cursor', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent', before: '' },
+    });
+    expect(result.isError).toBe(true);
+    expect(recipients).not.toHaveBeenCalled();
+  });
+
   it('reports when none are found', async () => {
     recipients.mockResolvedValue({ data: { has_more: false, data: [] } });
     const client = await makeClient();

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -321,6 +321,45 @@ describe('list-broadcast-recipients', () => {
     expect(textOf(result as never)).toContain('Bounce type: permanent');
   });
 
+  it('omits bounce type when it is null', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: false,
+        data: [
+          {
+            id: 'rcp_1',
+            contact_id: null,
+            email: 'a@b.com',
+            bounce_type: null,
+          },
+        ],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'bounced' },
+    });
+    expect(textOf(result as never)).not.toContain('Bounce type:');
+  });
+
+  it('rejects bounceType when type is not bounced', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: {
+        broadcastId: 'bc_1',
+        type: 'sent',
+        bounceType: 'permanent',
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain(
+      '"bounceType" is only valid when type is "bounced"',
+    );
+    expect(recipients).not.toHaveBeenCalled();
+  });
+
   it('includes clicked links for clicked recipients', async () => {
     recipients.mockResolvedValue({
       data: {
@@ -429,9 +468,22 @@ describe('list-broadcast-recipients', () => {
       name: 'list-broadcast-recipients',
       arguments: { broadcastId: 'bc_1', type: 'sent' },
     });
-    expect(textOf(result as never)).toContain(
-      'There are more recipients available',
-    );
+    expect(textOf(result as never)).toContain('Use the "after" parameter');
+  });
+
+  it('shows a backward-pagination has_more hint when paging with before', async () => {
+    recipients.mockResolvedValue({
+      data: {
+        has_more: true,
+        data: [{ id: 'rcp_1', contact_id: null, email: 'a@b.com' }],
+      },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-broadcast-recipients',
+      arguments: { broadcastId: 'bc_1', type: 'sent', before: 'rcp_9' },
+    });
+    expect(textOf(result as never)).toContain('Use the "before" parameter');
   });
 
   it('surfaces SDK errors', async () => {


### PR DESCRIPTION
Adds a list-broadcast-recipients tool for GET /broadcasts/{id}/recipients.

Tests: 185 passed. Lint/typecheck/build clean.