### PR TITLE
feat: add email-metrics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ You can pass additional arguments to configure the local server:
 
 Resend's MCP server gives your AI agent native access to the full Resend platform through a single integration. You can manage all aspects of your email infrastructure using natural language.
 
-- **Emails**: Send, list, get, cancel, update, share, and batch send emails. Supports HTML, plain text, attachments (local file, URL, or base64), CC/BCC, reply-to, scheduling, tags, custom headers, topic-based sending, and idempotency keys.
+- **Emails**: Send, list, get, cancel, update, share, and batch send emails. Retrieve delivery and engagement metrics. Supports HTML, plain text, attachments (local file, URL, or base64), CC/BCC, reply-to, scheduling, tags, custom headers, topic-based sending, and idempotency keys.
 - **Received Emails**: List and read inbound emails. List and download received email attachments.
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -1035,10 +1035,11 @@ export function addEmailTools(
           // the id as a fallback if the name is missing/blank so the label is never
           // empty, and never show a blank/missing name field on its own.
           const hasDomainName =
-            typeof row.domain_name === 'string' && row.domain_name.length > 0;
+            typeof row.domain_name === 'string' &&
+            row.domain_name.trim().length > 0;
           const hasBroadcastName =
             typeof row.broadcast_name === 'string' &&
-            row.broadcast_name.length > 0;
+            row.broadcast_name.trim().length > 0;
           const labelFields = Object.entries(row).filter(([key]) => {
             if (data.metrics.includes(key as never)) return false;
             if (key === 'domain_id') return !hasDomainName;

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -958,19 +958,22 @@ export function addEmailTools(
             'Dimensions to break the response down by. "email" and "broadcast" cannot be combined. Defaults to none, which returns totals only.',
           ),
         domainId: z
-          .array(z.string())
+          .array(z.uuid())
+          .max(100)
           .optional()
           .describe(
             'Restrict the response to these sending domain IDs (max 100).',
           ),
         emailId: z
-          .array(z.string())
+          .array(z.uuid())
+          .max(100)
           .optional()
           .describe(
             'Restrict the response to these email IDs (max 100). Cannot be combined with the "broadcast" dimension or broadcastId.',
           ),
         broadcastId: z
-          .array(z.string())
+          .array(z.uuid())
+          .max(100)
           .optional()
           .describe(
             'Restrict the response to these broadcast IDs (max 100). Cannot be combined with the "email" dimension or emailId.',
@@ -1028,9 +1031,22 @@ export function addEmailTools(
       if (data.data && data.data.length > 0) {
         text += `\nBreakdown by ${data.dimensions.join(', ')}:\n`;
         for (const row of data.data) {
-          const labelFields = Object.entries(row).filter(
-            ([key]) => !data.metrics.includes(key as never),
-          );
+          // Prefer domain_name/broadcast_name over the raw id when present, but keep
+          // the id as a fallback if the name is missing/blank so the label is never
+          // empty, and never show a blank/missing name field on its own.
+          const hasDomainName =
+            typeof row.domain_name === 'string' && row.domain_name.length > 0;
+          const hasBroadcastName =
+            typeof row.broadcast_name === 'string' &&
+            row.broadcast_name.length > 0;
+          const labelFields = Object.entries(row).filter(([key]) => {
+            if (data.metrics.includes(key as never)) return false;
+            if (key === 'domain_id') return !hasDomainName;
+            if (key === 'broadcast_id') return !hasBroadcastName;
+            if (key === 'domain_name') return hasDomainName;
+            if (key === 'broadcast_name') return hasBroadcastName;
+            return true;
+          });
           const label = labelFields.map(([, value]) => value).join(' / ');
           const metricValues = data.metrics
             .map((metric) => `${metric}: ${row[metric]}`)

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -889,7 +889,7 @@ export function addEmailTools(
   );
 
   server.registerTool(
-    'email-metrics',
+    'get-email-metrics',
     {
       title: 'Email Metrics',
       annotations: { readOnlyHint: true },

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -889,6 +889,168 @@ export function addEmailTools(
   );
 
   server.registerTool(
+    'email-metrics',
+    {
+      title: 'Email Metrics',
+      annotations: { readOnlyHint: true },
+      description:
+        'Retrieve account-level email delivery and engagement metrics (sent, delivered, bounced, opened, clicked, etc.) for a date range, optionally broken down by period, domain, email, or broadcast.',
+      inputSchema: {
+        startDate: z
+          .string()
+          .optional()
+          .describe(
+            'Start of the date range, as an ISO 8601 date or datetime. Defaults to 6 days before endDate.',
+          ),
+        endDate: z
+          .string()
+          .optional()
+          .describe(
+            'End of the date range, as an ISO 8601 date or datetime. Defaults to now.',
+          ),
+        timezone: z
+          .string()
+          .optional()
+          .describe(
+            'IANA timezone (e.g. "America/New_York") used to bucket periods when "period" is in dimensions. Defaults to UTC.',
+          ),
+        granularity: z
+          .enum(['hourly', 'daily', 'weekly', 'monthly'])
+          .optional()
+          .describe(
+            'Bucket size used when "period" is in dimensions. Defaults to "daily".',
+          ),
+        metrics: z
+          .array(
+            z.enum([
+              'received',
+              'delivered',
+              'complained',
+              'suppressed',
+              'bounced',
+              'bounced_transient',
+              'bounced_permanent',
+              'bounced_undetermined',
+              'opened',
+              'clicked',
+              'unsubscribed',
+              'delivery_delayed',
+              'failed',
+              'sent',
+              'unique_opened',
+              'unique_clicked',
+              'delivery_rate',
+              'open_rate',
+              'click_rate',
+              'bounce_rate',
+              'complaint_rate',
+              'unsubscribe_rate',
+            ]),
+          )
+          .optional()
+          .describe(
+            'Metrics to include in the response. Defaults to all metrics.',
+          ),
+        dimensions: z
+          .array(z.enum(['period', 'domain', 'email', 'broadcast']))
+          .optional()
+          .describe(
+            'Dimensions to break the response down by. "email" and "broadcast" cannot be combined. Defaults to none, which returns totals only.',
+          ),
+        domainId: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Restrict the response to these sending domain IDs (max 100).',
+          ),
+        emailId: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Restrict the response to these email IDs (max 100). Cannot be combined with the "broadcast" dimension or broadcastId.',
+          ),
+        broadcastId: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Restrict the response to these broadcast IDs (max 100). Cannot be combined with the "email" dimension or emailId.',
+          ),
+      },
+    },
+    async ({
+      startDate,
+      endDate,
+      timezone,
+      granularity,
+      metrics,
+      dimensions,
+      domainId,
+      emailId,
+      broadcastId,
+    }) => {
+      const hasEmail =
+        (dimensions?.includes('email') ?? false) || (emailId?.length ?? 0) > 0;
+      const hasBroadcast =
+        (dimensions?.includes('broadcast') ?? false) ||
+        (broadcastId?.length ?? 0) > 0;
+
+      if (hasEmail && hasBroadcast) {
+        throw new Error(
+          'Cannot combine the "broadcast" dimension/broadcastId filter with the "email" dimension/emailId filter.',
+        );
+      }
+
+      const response = await resend.emails.metrics({
+        startDate,
+        endDate,
+        timezone,
+        granularity,
+        metrics,
+        dimensions,
+        domainId,
+        emailId,
+        broadcastId,
+      } as Parameters<typeof resend.emails.metrics>[0]);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to retrieve email metrics: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const data = response.data;
+
+      let text = `Email metrics for ${data.start_date} to ${data.end_date} (${data.granularity} granularity):\n\nTotals:\n`;
+      for (const [metric, value] of Object.entries(data.totals)) {
+        text += `- ${metric}: ${value}\n`;
+      }
+
+      if (data.data && data.data.length > 0) {
+        text += `\nBreakdown by ${data.dimensions.join(', ')}:\n`;
+        for (const row of data.data) {
+          const labelFields = Object.entries(row).filter(
+            ([key]) => !data.metrics.includes(key as never),
+          );
+          const label = labelFields.map(([, value]) => value).join(' / ');
+          const metricValues = data.metrics
+            .map((metric) => `${metric}: ${row[metric]}`)
+            .join(', ');
+          text += `- ${label} — ${metricValues}\n`;
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     'list-sent-email-attachments',
     {
       title: 'List Sent Email Attachments',

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -508,6 +508,10 @@ describe('email-metrics', () => {
     expect(textOf(result)).toContain('sent: 100');
   });
 
+  const DOMAIN_ID = '11111111-1111-4111-8111-111111111111';
+  const EMAIL_ID = '22222222-2222-4222-8222-222222222222';
+  const BROADCAST_ID = '33333333-3333-4333-8333-333333333333';
+
   it('passes filters and dimensions through to the SDK', async () => {
     const client = await makeClient();
     await client.callTool({
@@ -516,7 +520,7 @@ describe('email-metrics', () => {
         startDate: '2026-07-01',
         endDate: '2026-07-08',
         dimensions: ['period', 'broadcast'],
-        broadcastId: ['b1'],
+        broadcastId: [BROADCAST_ID],
       },
     });
 
@@ -529,7 +533,32 @@ describe('email-metrics', () => {
       dimensions: ['period', 'broadcast'],
       domainId: undefined,
       emailId: undefined,
-      broadcastId: ['b1'],
+      broadcastId: [BROADCAST_ID],
+    });
+  });
+
+  it('passes domainId and email dimension/emailId through to the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: {
+        dimensions: ['email'],
+        emailId: [EMAIL_ID],
+        domainId: [DOMAIN_ID],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(metrics).toHaveBeenCalledWith({
+      startDate: undefined,
+      endDate: undefined,
+      timezone: undefined,
+      granularity: undefined,
+      metrics: undefined,
+      dimensions: ['email'],
+      domainId: [DOMAIN_ID],
+      emailId: [EMAIL_ID],
+      broadcastId: undefined,
     });
   });
 
@@ -548,7 +577,18 @@ describe('email-metrics', () => {
     const client = await makeClient();
     const result = await client.callTool({
       name: 'email-metrics',
-      arguments: { dimensions: ['broadcast'], emailId: ['e1'] },
+      arguments: { dimensions: ['broadcast'], emailId: [EMAIL_ID] },
+    });
+
+    expect(result.isError).toBeTruthy();
+    expect(metrics).not.toHaveBeenCalled();
+  });
+
+  it('rejects the email dimension combined with broadcastId, without calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: ['email'], broadcastId: [BROADCAST_ID] },
     });
 
     expect(result.isError).toBeTruthy();
@@ -559,14 +599,14 @@ describe('email-metrics', () => {
     const client = await makeClient();
     const result = await client.callTool({
       name: 'email-metrics',
-      arguments: { emailId: ['e1'], broadcastId: ['b1'] },
+      arguments: { emailId: [EMAIL_ID], broadcastId: [BROADCAST_ID] },
     });
 
     expect(result.isError).toBeTruthy();
     expect(metrics).not.toHaveBeenCalled();
   });
 
-  it('includes the breakdown rows when dimensions are requested', async () => {
+  it('includes the breakdown rows when dimensions are requested, preferring the name over the raw id', async () => {
     metrics.mockResolvedValue({
       data: {
         object: 'metrics',
@@ -578,7 +618,7 @@ describe('email-metrics', () => {
         totals: { sent: 100 },
         data: [
           {
-            broadcast_id: 'b1',
+            broadcast_id: BROADCAST_ID,
             broadcast_name: 'July Newsletter',
             sent: 100,
           },
@@ -593,8 +633,75 @@ describe('email-metrics', () => {
       arguments: { dimensions: ['broadcast'] },
     });
 
-    expect(textOf(result)).toContain('July Newsletter');
-    expect(textOf(result)).toContain('sent: 100');
+    const text = textOf(result);
+    expect(text).toContain('July Newsletter');
+    expect(text).toContain('sent: 100');
+    expect(text).not.toContain(BROADCAST_ID);
+  });
+
+  it.each([
+    {
+      dimension: 'domain' as const,
+      idKey: 'domain_id' as const,
+      id: DOMAIN_ID,
+    },
+    {
+      dimension: 'broadcast' as const,
+      idKey: 'broadcast_id' as const,
+      id: BROADCAST_ID,
+    },
+  ])('falls back to the raw id in the breakdown label when the $dimension name is missing', async ({
+    dimension,
+    idKey,
+    id,
+  }) => {
+    metrics.mockResolvedValue({
+      data: {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: [dimension],
+        granularity: 'daily',
+        totals: { sent: 100 },
+        data: [{ [idKey]: id, sent: 100 }],
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: [dimension] },
+    });
+
+    expect(textOf(result)).toContain(id);
+  });
+
+  it('falls back to the raw id when the name is an empty string', async () => {
+    metrics.mockResolvedValue({
+      data: {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: ['domain'],
+        granularity: 'daily',
+        totals: { sent: 100 },
+        data: [{ domain_id: DOMAIN_ID, domain_name: '', sent: 100 }],
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: ['domain'] },
+    });
+
+    const text = textOf(result);
+    // The id is the whole label - no stray blank segment from domain_name.
+    expect(text).toContain(`- ${DOMAIN_ID} — sent: 100`);
   });
 
   it('surfaces SDK errors', async () => {

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -7,9 +7,10 @@ import { addEmailTools } from '../../src/tools/emails.js';
 const send = vi.fn();
 const batchSend = vi.fn();
 const share = vi.fn();
+const metrics = vi.fn();
 
 const resend = {
-  emails: { send, share },
+  emails: { send, share, metrics },
   batch: { send: batchSend },
 } as unknown as Resend;
 
@@ -462,6 +463,150 @@ describe('share-email', () => {
     const result = await client.callTool({
       name: 'share-email',
       arguments: { id: 'missing_email' },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('email-metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    metrics.mockResolvedValue({
+      data: {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered'],
+        dimensions: [],
+        granularity: 'daily',
+        totals: { sent: 100, delivered: 95 },
+      },
+      error: null,
+    });
+  });
+
+  it('retrieves metrics with no options', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(metrics).toHaveBeenCalledWith({
+      startDate: undefined,
+      endDate: undefined,
+      timezone: undefined,
+      granularity: undefined,
+      metrics: undefined,
+      dimensions: undefined,
+      domainId: undefined,
+      emailId: undefined,
+      broadcastId: undefined,
+    });
+    expect(textOf(result)).toContain('sent: 100');
+  });
+
+  it('passes filters and dimensions through to the SDK', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'email-metrics',
+      arguments: {
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        dimensions: ['period', 'broadcast'],
+        broadcastId: ['b1'],
+      },
+    });
+
+    expect(metrics).toHaveBeenCalledWith({
+      startDate: '2026-07-01',
+      endDate: '2026-07-08',
+      timezone: undefined,
+      granularity: undefined,
+      metrics: undefined,
+      dimensions: ['period', 'broadcast'],
+      domainId: undefined,
+      emailId: undefined,
+      broadcastId: ['b1'],
+    });
+  });
+
+  it('rejects the email and broadcast dimensions combined, without calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: ['email', 'broadcast'] },
+    });
+
+    expect(result.isError).toBeTruthy();
+    expect(metrics).not.toHaveBeenCalled();
+  });
+
+  it('rejects the broadcast dimension combined with emailId, without calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: ['broadcast'], emailId: ['e1'] },
+    });
+
+    expect(result.isError).toBeTruthy();
+    expect(metrics).not.toHaveBeenCalled();
+  });
+
+  it('rejects emailId and broadcastId combined, without calling the SDK', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { emailId: ['e1'], broadcastId: ['b1'] },
+    });
+
+    expect(result.isError).toBeTruthy();
+    expect(metrics).not.toHaveBeenCalled();
+  });
+
+  it('includes the breakdown rows when dimensions are requested', async () => {
+    metrics.mockResolvedValue({
+      data: {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: ['broadcast'],
+        granularity: 'daily',
+        totals: { sent: 100 },
+        data: [
+          {
+            broadcast_id: 'b1',
+            broadcast_name: 'July Newsletter',
+            sent: 100,
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: { dimensions: ['broadcast'] },
+    });
+
+    expect(textOf(result)).toContain('July Newsletter');
+    expect(textOf(result)).toContain('sent: 100');
+  });
+
+  it('surfaces SDK errors', async () => {
+    metrics.mockResolvedValue({
+      data: null,
+      error: { name: 'validation_error', message: 'Invalid start_date' },
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'email-metrics',
+      arguments: {},
     });
 
     expect(result.isError).toBe(true);

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -469,7 +469,7 @@ describe('share-email', () => {
   });
 });
 
-describe('email-metrics', () => {
+describe('get-email-metrics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     metrics.mockResolvedValue({
@@ -489,7 +489,7 @@ describe('email-metrics', () => {
   it('retrieves metrics with no options', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: {},
     });
 
@@ -515,7 +515,7 @@ describe('email-metrics', () => {
   it('passes filters and dimensions through to the SDK', async () => {
     const client = await makeClient();
     await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: {
         startDate: '2026-07-01',
         endDate: '2026-07-08',
@@ -540,7 +540,7 @@ describe('email-metrics', () => {
   it('passes domainId and email dimension/emailId through to the SDK', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: {
         dimensions: ['email'],
         emailId: [EMAIL_ID],
@@ -565,7 +565,7 @@ describe('email-metrics', () => {
   it('rejects the email and broadcast dimensions combined, without calling the SDK', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: ['email', 'broadcast'] },
     });
 
@@ -576,7 +576,7 @@ describe('email-metrics', () => {
   it('rejects the broadcast dimension combined with emailId, without calling the SDK', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: ['broadcast'], emailId: [EMAIL_ID] },
     });
 
@@ -587,7 +587,7 @@ describe('email-metrics', () => {
   it('rejects the email dimension combined with broadcastId, without calling the SDK', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: ['email'], broadcastId: [BROADCAST_ID] },
     });
 
@@ -598,7 +598,7 @@ describe('email-metrics', () => {
   it('rejects emailId and broadcastId combined, without calling the SDK', async () => {
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { emailId: [EMAIL_ID], broadcastId: [BROADCAST_ID] },
     });
 
@@ -629,7 +629,7 @@ describe('email-metrics', () => {
 
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: ['broadcast'] },
     });
 
@@ -671,7 +671,7 @@ describe('email-metrics', () => {
 
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: [dimension] },
     });
 
@@ -695,7 +695,7 @@ describe('email-metrics', () => {
 
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: { dimensions: ['domain'] },
     });
 
@@ -712,7 +712,7 @@ describe('email-metrics', () => {
 
     const client = await makeClient();
     const result = await client.callTool({
-      name: 'email-metrics',
+      name: 'get-email-metrics',
       arguments: {},
     });
 

--- a/tests/tools/emails.test.ts
+++ b/tests/tools/emails.test.ts
@@ -675,7 +675,7 @@ describe('email-metrics', () => {
       arguments: { dimensions: [dimension] },
     });
 
-    expect(textOf(result)).toContain(id);
+    expect(textOf(result)).toContain(`- ${id} — sent: 100`);
   });
 
   it('falls back to the raw id when the name is an empty string', async () => {


### PR DESCRIPTION
Adds an `email-metrics` MCP tool for account-level email metrics — period/domain/email/broadcast dimensions, domain_id/email_id/broadcast_id filters (broadcast and email mutually exclusive), all granularities.

Mirrors https://github.com/resend/resend-node/pull/1079.