### PR TITLE
fix(broadcasts): align list-broadcast-recipients with the remote-mcp twin

### DIFF
--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -876,7 +876,7 @@ export function addBroadcastTools(
       annotations: { readOnlyHint: true },
       description: `**Purpose:** List the individual recipients of a broadcast for a given event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed).
 
-**NOT for:** Listing broadcasts themselves (use list-broadcasts). Not for aggregate/summary stats — this returns per-recipient rows, one per contact per event type.
+**NOT for:** Aggregate broadcast performance (use get-broadcast). Not for listing broadcasts themselves (use list-broadcasts). This tool returns per-recipient rows, one per contact per event type.
 
 **Returns:** For each recipient: email, id (opaque pagination cursor), contact_id (when known). Also includes count for "opened"/"clicked", bounce_type for "bounced", and clicked_links (url + click count) for "clicked". Use pagination (limit, after/before) for large lists.
 
@@ -912,6 +912,7 @@ export function addBroadcastTools(
           ),
         limit: z
           .number()
+          .int()
           .min(1)
           .max(100)
           .optional()
@@ -923,14 +924,14 @@ export function addBroadcastTools(
           .nonempty()
           .optional()
           .describe(
-            'Recipient ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+            'Cursor to fetch the page after this recipient (for forward pagination). Cannot be used with "before".',
           ),
         before: z
           .string()
           .nonempty()
           .optional()
           .describe(
-            'Recipient ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+            'Cursor to fetch the page before this recipient (for backward pagination). Cannot be used with "after".',
           ),
       },
     },


### PR DESCRIPTION
## What

Three changes to the `list-broadcast-recipients` tool:

- Add `.int()` to the `limit` schema. The spec types it as an integer; a fractional limit passed client validation before.
- Reword `after`/`before` to cursor phrasing. The recipient `id` is an opaque cursor, and the old "Recipient ID after which..." phrasing contradicted the description's own opaque-cursor note. The docs page uses the cursor phrasing.
- Point aggregate questions at `get-broadcast` in the **NOT for** line.

## Why

The monorepo remote-mcp twin and this tool were written an hour apart with different text. The two surfaces should match. This PR takes the three points where the twin was better; a monorepo PR aligns the rest of the twin's text to this repo's richer version (all 8 event types in the purpose line, the opaque-cursor note, the substring email wording, the get-broadcast-first hint).

Follow-up from the recipients rollout review.

## Checks

`pnpm test` 212/212, `pnpm build`, `pnpm lint` (3 pre-existing warnings), dependency pin check all pass.