### PR TITLE
chore: bump version to 2.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps the version for the release that ships:
- feat: add list-broadcast-clicked-links tool (#214)
- feat: add email-metrics tool (#216)
- feat(broadcasts): add list-broadcast-recipients tool (#215)