### PR TITLE
fix: hoist tool schemas to module scope to cut memory growth

### DIFF
--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -2,29 +2,81 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_API_KEY_TOOL = {
+  title: 'Create API Key',
+  description:
+    'Create a new API key in Resend. The token is only shown once upon creation, so you MUST display it to the user.',
+  inputSchema: {
+    name: z.string().nonempty().describe('API key name'),
+    permission: z
+      .enum(['full_access', 'sending_access'])
+      .optional()
+      .describe(
+        'Access level. "full_access" grants complete resource management. "sending_access" restricts to email delivery only.',
+      ),
+    domainId: z
+      .string()
+      .optional()
+      .describe(
+        'Restrict API key to send emails from a specific domain. Only applicable when permission is "sending_access".',
+      ),
+  },
+} as const;
+
+const LIST_API_KEYS_TOOL = {
+  title: 'List API Keys',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all API keys from Resend. Returns API key names, IDs, and creation dates. Don't bother telling the user the IDs or creation dates unless they ask for them.",
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of API keys to retrieve. Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'API key ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'API key ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const UPDATE_API_KEY_TOOL = {
+  title: 'Update API Key',
+  description: 'Rename an existing API key in Resend.',
+  inputSchema: {
+    id: z.string().nonempty().describe('API key ID'),
+    name: z.string().nonempty().describe('New API key name'),
+  },
+} as const;
+
+const REMOVE_API_KEY_TOOL = {
+  title: 'Remove API Key',
+  description:
+    'Remove an API key by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this API key. Reference the NAME of the API key when double-checking, and warn the user that removing an API key is irreversible and any services using it will lose access. You may only use this tool if the user explicitly confirms they want to remove the API key after you double-check.',
+  inputSchema: {
+    id: z.string().nonempty().describe('API key ID'),
+  },
+} as const;
+
 export function addApiKeyTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-api-key',
-    {
-      title: 'Create API Key',
-      description:
-        'Create a new API key in Resend. The token is only shown once upon creation, so you MUST display it to the user.',
-      inputSchema: {
-        name: z.string().nonempty().describe('API key name'),
-        permission: z
-          .enum(['full_access', 'sending_access'])
-          .optional()
-          .describe(
-            'Access level. "full_access" grants complete resource management. "sending_access" restricts to email delivery only.',
-          ),
-        domainId: z
-          .string()
-          .optional()
-          .describe(
-            'Restrict API key to send emails from a specific domain. Only applicable when permission is "sending_access".',
-          ),
-      },
-    },
+    CREATE_API_KEY_TOOL,
     async ({ name, permission, domainId }) => {
       const response = await resend.apiKeys.create({
         name,
@@ -57,32 +109,7 @@ export function addApiKeyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-api-keys',
-    {
-      title: 'List API Keys',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all API keys from Resend. Returns API key names, IDs, and creation dates. Don't bother telling the user the IDs or creation dates unless they ask for them.",
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe('Number of API keys to retrieve. Max: 100, Min: 1'),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'API key ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'API key ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_API_KEYS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -140,14 +167,7 @@ export function addApiKeyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'update-api-key',
-    {
-      title: 'Update API Key',
-      description: 'Rename an existing API key in Resend.',
-      inputSchema: {
-        id: z.string().nonempty().describe('API key ID'),
-        name: z.string().nonempty().describe('New API key name'),
-      },
-    },
+    UPDATE_API_KEY_TOOL,
     async ({ id, name }) => {
       const response = await resend.apiKeys.update(id, { name });
 
@@ -166,28 +186,17 @@ export function addApiKeyTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'remove-api-key',
-    {
-      title: 'Remove API Key',
-      description:
-        'Remove an API key by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this API key. Reference the NAME of the API key when double-checking, and warn the user that removing an API key is irreversible and any services using it will lose access. You may only use this tool if the user explicitly confirms they want to remove the API key after you double-check.',
-      inputSchema: {
-        id: z.string().nonempty().describe('API key ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.apiKeys.remove(id);
+  server.registerTool('remove-api-key', REMOVE_API_KEY_TOOL, async ({ id }) => {
+    const response = await resend.apiKeys.remove(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to remove API key: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to remove API key: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [{ type: 'text', text: 'API key removed successfully.' }],
-      };
-    },
-  );
+    return {
+      content: [{ type: 'text', text: 'API key removed successfully.' }],
+    };
+  });
 }

--- a/src/tools/apiKeys.ts
+++ b/src/tools/apiKeys.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_API_KEY_TOOL = {
   title: 'Create API Key',
   description:

--- a/src/tools/automations.ts
+++ b/src/tools/automations.ts
@@ -128,12 +128,14 @@ const workflowSchema = z
     'The workflow definition. See the tool description for the full schema and examples.',
   );
 
-export function addAutomationTools(server: McpServer, resend: Resend) {
-  server.registerTool(
-    'create-automation',
-    {
-      title: 'Create Automation',
-      description: `**Purpose:** Create an automation workflow that triggers on events and executes a sequence of steps.
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_AUTOMATION_TOOL = {
+  title: 'Create Automation',
+  description: `**Purpose:** Create an automation workflow that triggers on events and executes a sequence of steps.
 
 **When to use:**
 - User wants to set up automated email sequences (welcome series, drip campaigns, re-engagement)
@@ -144,20 +146,181 @@ export function addAutomationTools(server: McpServer, resend: Resend) {
 **Returns:** Automation ID and dashboard link.
 
 ${WORKFLOW_GUIDANCE}`,
-      inputSchema: {
-        name: z
-          .string()
-          .nonempty()
-          .describe('Name for the automation (e.g., "Welcome Series")'),
-        status: z
-          .enum(['enabled', 'disabled'])
-          .optional()
-          .describe(
-            'Initial status. Default: disabled. Use "enabled" to activate immediately.',
-          ),
-        workflow: workflowSchema,
-      },
-    },
+  inputSchema: {
+    name: z
+      .string()
+      .nonempty()
+      .describe('Name for the automation (e.g., "Welcome Series")'),
+    status: z
+      .enum(['enabled', 'disabled'])
+      .optional()
+      .describe(
+        'Initial status. Default: disabled. Use "enabled" to activate immediately.',
+      ),
+    workflow: workflowSchema,
+  },
+} as const;
+
+const UPDATE_AUTOMATION_TOOL = {
+  title: 'Update Automation',
+  description: `**Purpose:** Update an automation's name, status, or workflow.
+
+**When to use:**
+- User wants to rename an automation
+- User wants to enable or disable an automation (use status: "disabled" to stop it)
+- User wants to modify the workflow steps
+
+**Important:**
+- To disable/stop an automation, set status to "disabled". Existing runs will continue to completion.
+- When updating the workflow, provide the complete new workflow — it replaces the existing one.
+- Use get-automation first to see the current workflow before making changes.
+
+${WORKFLOW_GUIDANCE}`,
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
+      ),
+    name: z.string().optional().describe('New name for the automation.'),
+    status: z
+      .enum(['enabled', 'disabled'])
+      .optional()
+      .describe(
+        'New status. Use "disabled" to stop the automation (prevents new runs).',
+      ),
+    workflow: workflowSchema
+      .optional()
+      .describe(
+        'New workflow definition. Replaces the existing workflow entirely.',
+      ),
+  },
+} as const;
+
+const GET_AUTOMATION_TOOL = {
+  title: 'Get Automation',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** Get details of a specific automation (with its workflow) or list all automations.
+
+**Modes:**
+- With \`id\`: Returns full automation details including the workflow definition.
+- Without \`id\`: Lists all automations with optional status filter and pagination.
+
+**When to use:**
+- User asks "show me my automations" or "what automations do I have?"
+- User wants to inspect a specific automation's workflow
+- Before update-automation, to see the current workflow`,
+  inputSchema: {
+    id: z
+      .string()
+      .optional()
+      .describe(
+        'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>). If omitted, lists all automations.',
+      ),
+    status: z
+      .enum(['enabled', 'disabled'])
+      .optional()
+      .describe('Filter by status (for list mode only).'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of automations to retrieve (for list mode).'),
+    after: z
+      .string()
+      .optional()
+      .describe('Cursor for forward pagination (for list mode).'),
+    before: z
+      .string()
+      .optional()
+      .describe('Cursor for backward pagination (for list mode).'),
+  },
+} as const;
+
+const DUPLICATE_AUTOMATION_TOOL = {
+  title: 'Duplicate Automation',
+  description:
+    'Duplicate an existing automation by ID or Resend dashboard URL. Creates a copy with its own ID, including the steps and connections of the original. Use this when the user wants a new automation based on one they already have, instead of rebuilding the workflow from scratch. Use update-automation on the new ID to rename it or change its workflow.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>) of the automation to duplicate',
+      ),
+  },
+} as const;
+
+const REMOVE_AUTOMATION_TOOL = {
+  title: 'Remove Automation',
+  description:
+    'Remove an automation by ID or Resend dashboard URL. Before using this tool, you MUST double-check with the user that they want to remove this automation. Reference the NAME of the automation when confirming, and warn the user that removal is irreversible and will stop all future runs. You may only use this tool if the user explicitly confirms.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
+      ),
+  },
+} as const;
+
+const GET_AUTOMATION_RUNS_TOOL = {
+  title: 'Get Automation Runs',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List runs for an automation, or get details of a specific run.
+
+**Modes:**
+- With \`runId\`: Returns detailed run info with step-by-step execution status, outputs, and errors.
+- Without \`runId\`: Lists runs for the automation with optional status filter.
+
+**When to use:**
+- User wants to see if an automation is working
+- User wants to debug a failed automation run
+- User asks "why did this automation fail?" or "show me recent runs"
+
+**Run statuses:** running, completed, failed, cancelled
+**Step statuses:** pending, running, completed, failed, skipped, waiting`,
+  inputSchema: {
+    automationId: z
+      .string()
+      .nonempty()
+      .describe(
+        'The automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
+      ),
+    runId: z
+      .string()
+      .optional()
+      .describe(
+        'Specific run ID to get details for. If omitted, lists all runs.',
+      ),
+    status: z
+      .enum(['running', 'completed', 'failed', 'cancelled'])
+      .optional()
+      .describe('Filter runs by status (for list mode only).'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of runs to retrieve (for list mode).'),
+    after: z
+      .string()
+      .optional()
+      .describe('Cursor for forward pagination (for list mode).'),
+    before: z
+      .string()
+      .optional()
+      .describe('Cursor for backward pagination (for list mode).'),
+  },
+} as const;
+
+export function addAutomationTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'create-automation',
+    CREATE_AUTOMATION_TOOL,
     async ({ name, status, workflow }) => {
       const { steps, connections } = workflowToSdkOptions(
         workflow as WorkflowDefinition,
@@ -196,42 +359,7 @@ ${WORKFLOW_GUIDANCE}`,
 
   server.registerTool(
     'update-automation',
-    {
-      title: 'Update Automation',
-      description: `**Purpose:** Update an automation's name, status, or workflow.
-
-**When to use:**
-- User wants to rename an automation
-- User wants to enable or disable an automation (use status: "disabled" to stop it)
-- User wants to modify the workflow steps
-
-**Important:**
-- To disable/stop an automation, set status to "disabled". Existing runs will continue to completion.
-- When updating the workflow, provide the complete new workflow — it replaces the existing one.
-- Use get-automation first to see the current workflow before making changes.
-
-${WORKFLOW_GUIDANCE}`,
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
-          ),
-        name: z.string().optional().describe('New name for the automation.'),
-        status: z
-          .enum(['enabled', 'disabled'])
-          .optional()
-          .describe(
-            'New status. Use "disabled" to stop the automation (prevents new runs).',
-          ),
-        workflow: workflowSchema
-          .optional()
-          .describe(
-            'New workflow definition. Replaces the existing workflow entirely.',
-          ),
-      },
-    },
+    UPDATE_AUTOMATION_TOOL,
     async ({ id: rawId, name, status, workflow }) => {
       const id = extractIdFromUrl(rawId, 'automations');
       const updateOptions: {
@@ -278,46 +406,7 @@ ${WORKFLOW_GUIDANCE}`,
 
   server.registerTool(
     'get-automation',
-    {
-      title: 'Get Automation',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** Get details of a specific automation (with its workflow) or list all automations.
-
-**Modes:**
-- With \`id\`: Returns full automation details including the workflow definition.
-- Without \`id\`: Lists all automations with optional status filter and pagination.
-
-**When to use:**
-- User asks "show me my automations" or "what automations do I have?"
-- User wants to inspect a specific automation's workflow
-- Before update-automation, to see the current workflow`,
-      inputSchema: {
-        id: z
-          .string()
-          .optional()
-          .describe(
-            'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>). If omitted, lists all automations.',
-          ),
-        status: z
-          .enum(['enabled', 'disabled'])
-          .optional()
-          .describe('Filter by status (for list mode only).'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe('Number of automations to retrieve (for list mode).'),
-        after: z
-          .string()
-          .optional()
-          .describe('Cursor for forward pagination (for list mode).'),
-        before: z
-          .string()
-          .optional()
-          .describe('Cursor for backward pagination (for list mode).'),
-      },
-    },
+    GET_AUTOMATION_TOOL,
     async ({ id: rawId, status, limit, after, before }) => {
       const id = rawId ? extractIdFromUrl(rawId, 'automations') : undefined;
       // Get single automation
@@ -412,19 +501,7 @@ ${WORKFLOW_GUIDANCE}`,
 
   server.registerTool(
     'duplicate-automation',
-    {
-      title: 'Duplicate Automation',
-      description:
-        'Duplicate an existing automation by ID or Resend dashboard URL. Creates a copy with its own ID, including the steps and connections of the original. Use this when the user wants a new automation based on one they already have, instead of rebuilding the workflow from scratch. Use update-automation on the new ID to rename it or change its workflow.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>) of the automation to duplicate',
-          ),
-      },
-    },
+    DUPLICATE_AUTOMATION_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'automations');
       const response = await resend.automations.duplicate(id);
@@ -451,19 +528,7 @@ ${WORKFLOW_GUIDANCE}`,
 
   server.registerTool(
     'remove-automation',
-    {
-      title: 'Remove Automation',
-      description:
-        'Remove an automation by ID or Resend dashboard URL. Before using this tool, you MUST double-check with the user that they want to remove this automation. Reference the NAME of the automation when confirming, and warn the user that removal is irreversible and will stop all future runs. You may only use this tool if the user explicitly confirms.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'Automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
-          ),
-      },
-    },
+    REMOVE_AUTOMATION_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'automations');
       const response = await resend.automations.remove(id);
@@ -485,55 +550,7 @@ ${WORKFLOW_GUIDANCE}`,
 
   server.registerTool(
     'get-automation-runs',
-    {
-      title: 'Get Automation Runs',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List runs for an automation, or get details of a specific run.
-
-**Modes:**
-- With \`runId\`: Returns detailed run info with step-by-step execution status, outputs, and errors.
-- Without \`runId\`: Lists runs for the automation with optional status filter.
-
-**When to use:**
-- User wants to see if an automation is working
-- User wants to debug a failed automation run
-- User asks "why did this automation fail?" or "show me recent runs"
-
-**Run statuses:** running, completed, failed, cancelled
-**Step statuses:** pending, running, completed, failed, skipped, waiting`,
-      inputSchema: {
-        automationId: z
-          .string()
-          .nonempty()
-          .describe(
-            'The automation ID or Resend dashboard URL (e.g. https://resend.com/automations/<id>)',
-          ),
-        runId: z
-          .string()
-          .optional()
-          .describe(
-            'Specific run ID to get details for. If omitted, lists all runs.',
-          ),
-        status: z
-          .enum(['running', 'completed', 'failed', 'cancelled'])
-          .optional()
-          .describe('Filter runs by status (for list mode only).'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe('Number of runs to retrieve (for list mode).'),
-        after: z
-          .string()
-          .optional()
-          .describe('Cursor for forward pagination (for list mode).'),
-        before: z
-          .string()
-          .optional()
-          .describe('Cursor for backward pagination (for list mode).'),
-      },
-    },
+    GET_AUTOMATION_RUNS_TOOL,
     async ({
       automationId: rawAutomationId,
       runId,

--- a/src/tools/automations.ts
+++ b/src/tools/automations.ts
@@ -128,11 +128,6 @@ const workflowSchema = z
     'The workflow definition. See the tool description for the full schema and examples.',
   );
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_AUTOMATION_TOOL = {
   title: 'Create Automation',
   description: `**Purpose:** Create an automation workflow that triggers on events and executes a sequence of steps.

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -5,6 +5,391 @@ import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
 import type { ResendEditorClient } from '../lib/resend-editor-client.js';
 import { extractIdFromUrl } from '../lib/url-parser.js';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_BROADCAST_TOOL_BASE = {
+  title: 'Create Broadcast',
+  description: `**Purpose:** Create a broadcast campaign (one email sent to an entire segment). Defines subject, body, and segment; does NOT send yet. Use send-broadcast to send it.
+
+**NOT for:** Sending a one-off email to specific people (use send-email). Not for adding contacts (use create-contact).
+
+**Returns:** Broadcast ID. Use this ID with send-broadcast to send, or get-broadcast/update-broadcast to manage.
+
+**When to use:**
+- User wants to "email my list", "send a newsletter", "broadcast to my segment", "email all contacts in X"
+- Newsletter, announcement, or bulk message to one segment
+- Supports personalization: {{{FIRST_NAME}}}, {{{LAST_NAME}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}
+
+**"All contacts" note:** Broadcasts require a segment. There is no "all contacts" option in the API. If the user wants to send to all contacts, check list-segments for an existing segment that covers everyone. If none exists, suggest creating one with create-segment.
+
+**Workflow:** list-segments (if needed) → create-broadcast → get-tiptap-json-content (with include_schema: true) → compose-broadcast → send-broadcast.
+
+**Content options after creating:**
+- **compose-broadcast** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the email in the editor.
+- **update-broadcast with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
+} as const;
+
+// create-broadcast's inputSchema shape genuinely depends on senderEmailAddress /
+// replierEmailAddresses (server-wide config, fixed for the process's
+// lifetime — passed once into runHttp() at boot, never per-request). Cache
+// by that config instead of rebuilding on every request; in practice this is
+// a cache hit after the very first call.
+let cachedCreateBroadcastSchemaKey: string | undefined;
+let cachedCreateBroadcastInputSchema: ReturnType<
+  typeof buildCreateBroadcastInputSchema
+>;
+
+function buildCreateBroadcastInputSchema(
+  senderEmailAddress: string | undefined,
+  replierEmailAddresses: string[],
+) {
+  return {
+    name: z
+      .string()
+      .nonempty()
+      .describe(
+        'Name for the broadcast. If the user does not provide a name, go ahead and create a descriptive name for them, based on the email subject/content and the context of your conversation.',
+      ),
+    segmentId: z.string().nonempty().describe('Segment ID to send to'),
+    subject: z.string().nonempty().describe('Email subject'),
+    text: z
+      .string()
+      .optional()
+      .describe(
+        'Plain text version of the email content. The following placeholders may be used to personalize the email content: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
+      ),
+    html: z
+      .string()
+      .optional()
+      .describe(
+        `HTML version of the email content. Placeholders: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}.\n\n${EMAIL_HTML_RULES}`,
+      ),
+    previewText: z.string().optional().describe('Preview text for the email'),
+    ...(!senderEmailAddress
+      ? {
+          from: z
+            .string()
+            .nonempty()
+            .describe(
+              'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
+            ),
+        }
+      : {}),
+    ...(replierEmailAddresses.length === 0
+      ? {
+          replyTo: z
+            .array(z.string())
+            .optional()
+            .describe('Reply-to email address(es)'),
+        }
+      : {}),
+  };
+}
+
+function getCreateBroadcastInputSchema(
+  senderEmailAddress: string | undefined,
+  replierEmailAddresses: string[],
+) {
+  const key = `${senderEmailAddress ?? ''}|${replierEmailAddresses.join(',')}`;
+  if (cachedCreateBroadcastSchemaKey !== key) {
+    cachedCreateBroadcastInputSchema = buildCreateBroadcastInputSchema(
+      senderEmailAddress,
+      replierEmailAddresses,
+    );
+    cachedCreateBroadcastSchemaKey = key;
+  }
+  return cachedCreateBroadcastInputSchema;
+}
+
+const SEND_BROADCAST_TOOL = {
+  title: 'Send Broadcast',
+  description: `**Purpose:** Send (or schedule) an existing broadcast by ID. The broadcast must have been created with create-broadcast first.
+
+**NOT for:** Sending a new one-off email (use send-email). Not for creating the broadcast content (use create-broadcast).
+
+**Returns:** Send confirmation and broadcast ID.
+
+**When to use:**
+- User has created a broadcast and says "send it", "go ahead and send", "schedule this for tomorrow"
+- After create-broadcast; call send-broadcast with the returned ID to deliver to the audience
+- Optional scheduledAt: natural language or ISO 8601 for scheduled send
+
+**Workflow:** create-broadcast → send-broadcast. Use list-broadcasts to find existing draft/sent broadcasts.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+    scheduledAt: z
+      .string()
+      .optional()
+      .describe(
+        'When to send the broadcast. Value may be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z) or in natural language (e.g., "tomorrow at 10am", "in 2 hours", "next day at 9am PST", "Friday at 3pm ET"). If not provided, the broadcast will be sent immediately.',
+      ),
+  },
+} as const;
+
+const LIST_BROADCASTS_TOOL = {
+  title: 'List Broadcasts',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List all broadcast campaigns (newsletters/bulk emails to audiences) with ID, name, audience, status, timestamps.
+
+**NOT for:** Listing transactional emails (use list-emails). Not for listing segments or contacts (use list-segments, list-contacts).
+
+**Returns:** For each broadcast: id, name, segment_id, status, created_at, scheduled_at, sent_at.
+
+**When to use:** User asks "show my broadcasts", "what newsletters did I send?", "list campaigns". Use get-broadcast for full details of one.`,
+  inputSchema: {},
+} as const;
+
+const GET_BROADCAST_TOOL = {
+  title: 'Get Broadcast',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve full details of a specific broadcast by ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>), including HTML and plain text content.',
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+  },
+} as const;
+
+const CANCEL_BROADCAST_TOOL = {
+  title: 'Cancel Broadcast',
+  description: `**Purpose:** Cancel a queued or scheduled broadcast by ID or Resend dashboard URL, without removing it. Cancelling a queued broadcast stops it mid-send (emails already sent are not affected). Cancelling a scheduled broadcast reverts it to draft.
+
+**NOT for:** Removing a broadcast entirely (use remove-broadcast). Draft and sent broadcasts cannot be cancelled — sent broadcasts are immutable, and drafts have nothing to cancel.
+
+**When to use:** User wants to "stop", "cancel", or "pause" a broadcast that is currently sending or scheduled to send.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+  },
+} as const;
+
+const REMOVE_BROADCAST_TOOL = {
+  title: 'Remove Broadcast',
+  description:
+    'Remove a broadcast by ID or Resend dashboard URL. Before using this tool, you MUST double-check with the user that they want to remove this broadcast. Reference the NAME of the broadcast when double-checking, and warn the user that removing a broadcast is irreversible. You may only use this tool if the user explicitly confirms they want to remove the broadcast after you double-check.',
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+  },
+} as const;
+
+const COMPOSE_BROADCAST_TOOL = {
+  title: 'Compose Broadcast',
+  description: `**Purpose:** Set the TipTap JSON content of a broadcast, enabling it to be edited visually in the Resend dashboard editor. Automatically connects and disconnects from the editor. Can also update metadata (subject, preview text, name) in the same call.
+
+**This is the recommended way to set email content.** Content set via compose-broadcast can be visually edited by the user in the dashboard. Use this for newsletters and any broadcast where the user may want to refine the content.
+
+**Workflow:** get-tiptap-json-content (with include_schema: true) → compose-broadcast
+
+**When to use:**
+- After create-broadcast, to set the email body
+- When the user wants to write, edit, or style email content
+- When the user wants to collaborate on the email in the dashboard editor
+
+**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+
+**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the broadcast already has HTML content, ask the user before switching to compose mode.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+    content: z
+      .preprocess(
+        (val) => {
+          if (typeof val === 'string') {
+            try {
+              return JSON.parse(val);
+            } catch {
+              return val;
+            }
+          }
+          return val;
+        },
+        z.record(z.string(), z.unknown()),
+      )
+      .describe(
+        'TipTap JSON content. Call get-tiptap-json-content (with include_schema: true) first to get the existing content and the schema reference.',
+      ),
+    subject: z.string().optional().describe('Update the email subject line.'),
+    previewText: z
+      .string()
+      .optional()
+      .describe(
+        'Update the preview text (shown in inbox before opening the email).',
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe('Update the broadcast name (internal label).'),
+  },
+} as const;
+
+const UPDATE_BROADCAST_TOOL = {
+  title: 'Update Broadcast',
+  description: `Update broadcast metadata by ID or Resend dashboard URL (name, subject, from, html, text, segment, preview text, reply-to). To edit TipTap content, use compose-broadcast instead.
+
+**Important:** The API requires \`from\` and \`segmentId\` to be set on the broadcast. If the broadcast was created from the dashboard, these may be empty. Always call get-broadcast first to check, and include \`from\` and \`segmentId\` in your update if they are not already set. Use list-domains to find verified domains for the from address, and list-segments to find segment IDs.
+
+**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-broadcast. This switch is lossy — some content or formatting may be lost. Prefer compose-broadcast for content changes. If the broadcast was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+    name: z.string().optional().describe('Name for the broadcast'),
+    segmentId: z.string().optional().describe('Segment ID to send to'),
+    from: z
+      .string()
+      .optional()
+      .describe(
+        'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
+      ),
+    html: z
+      .string()
+      .optional()
+      .describe(`HTML content of the email.\n\n${EMAIL_HTML_RULES}`),
+    text: z.string().optional().describe('Plain text content of the email'),
+    subject: z.string().optional().describe('Email subject'),
+    replyTo: z
+      .array(z.string())
+      .optional()
+      .describe('Reply-to email address(es)'),
+    previewText: z.string().optional().describe('Preview text for the email'),
+  },
+} as const;
+
+const LIST_BROADCAST_CLICKED_LINKS_TOOL = {
+  title: 'List Broadcast Clicked Links',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List the links clicked in a broadcast, ranked by total clicks.
+
+**Returns:** For each link: id (opaque pagination cursor for that row, not an entity id), url, clicks (total), unique_clicks. Use pagination (limit, after/before) for large lists.
+
+**When to use:**
+- User asks "what links were clicked in this broadcast?", "top clicked links", "click breakdown for this campaign"
+- Use get-broadcast for overall broadcast details; use this for per-link click data.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of links to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        'Cursor after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        'Cursor before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const LIST_BROADCAST_RECIPIENTS_TOOL = {
+  title: 'List Broadcast Recipients',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List the individual recipients of a broadcast for a given event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed).
+
+**NOT for:** Aggregate broadcast performance (use get-broadcast). Not for listing broadcasts themselves (use list-broadcasts). This tool returns per-recipient rows, one per contact per event type.
+
+**Returns:** For each recipient: email, id (opaque pagination cursor), contact_id (when known). Also includes count for "opened"/"clicked", bounce_type for "bounced", and clicked_links (url + click count) for "clicked". Use pagination (limit, after/before) for large lists.
+
+**When to use:** User asks "who opened this broadcast?", "who bounced?", "who clicked this link?", "who unsubscribed from this campaign?", or wants the list of contacts behind a specific broadcast engagement metric. Use get-broadcast first if you need the broadcast ID from a name.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+    type: z
+      .enum([
+        'sent',
+        'delivered',
+        'opened',
+        'clicked',
+        'bounced',
+        'complained',
+        'unsubscribed',
+        'suppressed',
+      ])
+      .describe('Recipient event type to list recipients for.'),
+    email: z
+      .string()
+      .optional()
+      .describe('Filter recipients by a substring of their email address.'),
+    bounceType: z
+      .enum(['permanent', 'transient', 'undetermined'])
+      .optional()
+      .describe(
+        'Filter by bounce type. Only meaningful when "type" is "bounced".',
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of recipients to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .nonempty()
+      .optional()
+      .describe(
+        'Cursor to fetch the page after this recipient (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .nonempty()
+      .optional()
+      .describe(
+        'Cursor to fetch the page before this recipient (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
 export function addBroadcastTools(
   server: McpServer,
   resend: Resend,
@@ -26,69 +411,11 @@ export function addBroadcastTools(
   server.registerTool(
     'create-broadcast',
     {
-      title: 'Create Broadcast',
-      description: `**Purpose:** Create a broadcast campaign (one email sent to an entire segment). Defines subject, body, and segment; does NOT send yet. Use send-broadcast to send it.
-
-**NOT for:** Sending a one-off email to specific people (use send-email). Not for adding contacts (use create-contact).
-
-**Returns:** Broadcast ID. Use this ID with send-broadcast to send, or get-broadcast/update-broadcast to manage.
-
-**When to use:**
-- User wants to "email my list", "send a newsletter", "broadcast to my segment", "email all contacts in X"
-- Newsletter, announcement, or bulk message to one segment
-- Supports personalization: {{{FIRST_NAME}}}, {{{LAST_NAME}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}
-
-**"All contacts" note:** Broadcasts require a segment. There is no "all contacts" option in the API. If the user wants to send to all contacts, check list-segments for an existing segment that covers everyone. If none exists, suggest creating one with create-segment.
-
-**Workflow:** list-segments (if needed) → create-broadcast → get-tiptap-json-content (with include_schema: true) → compose-broadcast → send-broadcast.
-
-**Content options after creating:**
-- **compose-broadcast** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the email in the editor.
-- **update-broadcast with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
-      inputSchema: {
-        name: z
-          .string()
-          .nonempty()
-          .describe(
-            'Name for the broadcast. If the user does not provide a name, go ahead and create a descriptive name for them, based on the email subject/content and the context of your conversation.',
-          ),
-        segmentId: z.string().nonempty().describe('Segment ID to send to'),
-        subject: z.string().nonempty().describe('Email subject'),
-        text: z
-          .string()
-          .optional()
-          .describe(
-            'Plain text version of the email content. The following placeholders may be used to personalize the email content: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
-          ),
-        html: z
-          .string()
-          .optional()
-          .describe(
-            `HTML version of the email content. Placeholders: {{{FIRST_NAME|fallback}}}, {{{LAST_NAME|fallback}}}, {{{EMAIL}}}, {{{RESEND_UNSUBSCRIBE_URL}}}.\n\n${EMAIL_HTML_RULES}`,
-          ),
-        previewText: z
-          .string()
-          .optional()
-          .describe('Preview text for the email'),
-        ...(!senderEmailAddress
-          ? {
-              from: z
-                .string()
-                .nonempty()
-                .describe(
-                  'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
-                ),
-            }
-          : {}),
-        ...(replierEmailAddresses.length === 0
-          ? {
-              replyTo: z
-                .array(z.string())
-                .optional()
-                .describe('Reply-to email address(es)'),
-            }
-          : {}),
-      },
+      ...CREATE_BROADCAST_TOOL_BASE,
+      inputSchema: getCreateBroadcastInputSchema(
+        senderEmailAddress,
+        replierEmailAddresses,
+      ),
     },
     async ({
       name,
@@ -182,35 +509,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'send-broadcast',
-    {
-      title: 'Send Broadcast',
-      description: `**Purpose:** Send (or schedule) an existing broadcast by ID. The broadcast must have been created with create-broadcast first.
-
-**NOT for:** Sending a new one-off email (use send-email). Not for creating the broadcast content (use create-broadcast).
-
-**Returns:** Send confirmation and broadcast ID.
-
-**When to use:**
-- User has created a broadcast and says "send it", "go ahead and send", "schedule this for tomorrow"
-- After create-broadcast; call send-broadcast with the returned ID to deliver to the audience
-- Optional scheduledAt: natural language or ISO 8601 for scheduled send
-
-**Workflow:** create-broadcast → send-broadcast. Use list-broadcasts to find existing draft/sent broadcasts.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-        scheduledAt: z
-          .string()
-          .optional()
-          .describe(
-            'When to send the broadcast. Value may be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z) or in natural language (e.g., "tomorrow at 10am", "in 2 hours", "next day at 9am PST", "Friday at 3pm ET"). If not provided, the broadcast will be sent immediately.',
-          ),
-      },
-    },
+    SEND_BROADCAST_TOOL,
     async ({ broadcastId: rawBroadcastId, scheduledAt }) => {
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
       const response = await resend.broadcasts.send(broadcastId, {
@@ -234,18 +533,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'list-broadcasts',
-    {
-      title: 'List Broadcasts',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List all broadcast campaigns (newsletters/bulk emails to audiences) with ID, name, audience, status, timestamps.
-
-**NOT for:** Listing transactional emails (use list-emails). Not for listing segments or contacts (use list-segments, list-contacts).
-
-**Returns:** For each broadcast: id, name, segment_id, status, created_at, scheduled_at, sent_at.
-
-**When to use:** User asks "show my broadcasts", "what newsletters did I send?", "list campaigns". Use get-broadcast for full details of one.`,
-      inputSchema: {},
-    },
+    LIST_BROADCASTS_TOOL,
     async (_args, _ctx) => {
       const response = await resend.broadcasts.list();
 
@@ -293,20 +581,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'get-broadcast',
-    {
-      title: 'Get Broadcast',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve full details of a specific broadcast by ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>), including HTML and plain text content.',
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-      },
-    },
+    GET_BROADCAST_TOOL,
     async ({ broadcastId: rawBroadcastId }) => {
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
       const response = await resend.broadcasts.get(broadcastId);
@@ -367,22 +642,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'cancel-broadcast',
-    {
-      title: 'Cancel Broadcast',
-      description: `**Purpose:** Cancel a queued or scheduled broadcast by ID or Resend dashboard URL, without removing it. Cancelling a queued broadcast stops it mid-send (emails already sent are not affected). Cancelling a scheduled broadcast reverts it to draft.
-
-**NOT for:** Removing a broadcast entirely (use remove-broadcast). Draft and sent broadcasts cannot be cancelled — sent broadcasts are immutable, and drafts have nothing to cancel.
-
-**When to use:** User wants to "stop", "cancel", or "pause" a broadcast that is currently sending or scheduled to send.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-      },
-    },
+    CANCEL_BROADCAST_TOOL,
     async ({ broadcastId: rawBroadcastId }) => {
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
       const response = await resend.broadcasts.cancel(broadcastId);
@@ -404,19 +664,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'remove-broadcast',
-    {
-      title: 'Remove Broadcast',
-      description:
-        'Remove a broadcast by ID or Resend dashboard URL. Before using this tool, you MUST double-check with the user that they want to remove this broadcast. Reference the NAME of the broadcast when double-checking, and warn the user that removing a broadcast is irreversible. You may only use this tool if the user explicitly confirms they want to remove the broadcast after you double-check.',
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-      },
-    },
+    REMOVE_BROADCAST_TOOL,
     async ({ broadcastId: rawBroadcastId }) => {
       const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
       const response = await resend.broadcasts.remove(broadcastId);
@@ -438,62 +686,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'compose-broadcast',
-    {
-      title: 'Compose Broadcast',
-      description: `**Purpose:** Set the TipTap JSON content of a broadcast, enabling it to be edited visually in the Resend dashboard editor. Automatically connects and disconnects from the editor. Can also update metadata (subject, preview text, name) in the same call.
-
-**This is the recommended way to set email content.** Content set via compose-broadcast can be visually edited by the user in the dashboard. Use this for newsletters and any broadcast where the user may want to refine the content.
-
-**Workflow:** get-tiptap-json-content (with include_schema: true) → compose-broadcast
-
-**When to use:**
-- After create-broadcast, to set the email body
-- When the user wants to write, edit, or style email content
-- When the user wants to collaborate on the email in the dashboard editor
-
-**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
-
-**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the broadcast already has HTML content, ask the user before switching to compose mode.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-        content: z
-          .preprocess(
-            (val) => {
-              if (typeof val === 'string') {
-                try {
-                  return JSON.parse(val);
-                } catch {
-                  return val;
-                }
-              }
-              return val;
-            },
-            z.record(z.string(), z.unknown()),
-          )
-          .describe(
-            'TipTap JSON content. Call get-tiptap-json-content (with include_schema: true) first to get the existing content and the schema reference.',
-          ),
-        subject: z
-          .string()
-          .optional()
-          .describe('Update the email subject line.'),
-        previewText: z
-          .string()
-          .optional()
-          .describe(
-            'Update the preview text (shown in inbox before opening the email).',
-          ),
-        name: z
-          .string()
-          .optional()
-          .describe('Update the broadcast name (internal label).'),
-      },
-    },
+    COMPOSE_BROADCAST_TOOL,
     async (
       { broadcastId: rawBroadcastId, content, subject, previewText, name },
       ctx,
@@ -638,44 +831,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'update-broadcast',
-    {
-      title: 'Update Broadcast',
-      description: `Update broadcast metadata by ID or Resend dashboard URL (name, subject, from, html, text, segment, preview text, reply-to). To edit TipTap content, use compose-broadcast instead.
-
-**Important:** The API requires \`from\` and \`segmentId\` to be set on the broadcast. If the broadcast was created from the dashboard, these may be empty. Always call get-broadcast first to check, and include \`from\` and \`segmentId\` in your update if they are not already set. Use list-domains to find verified domains for the from address, and list-segments to find segment IDs.
-
-**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-broadcast. This switch is lossy — some content or formatting may be lost. Prefer compose-broadcast for content changes. If the broadcast was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-        name: z.string().optional().describe('Name for the broadcast'),
-        segmentId: z.string().optional().describe('Segment ID to send to'),
-        from: z
-          .string()
-          .optional()
-          .describe(
-            'From email address (e.g. "onboarding@resend.com" or "Resend <onboarding@resend.com>")',
-          ),
-        html: z
-          .string()
-          .optional()
-          .describe(`HTML content of the email.\n\n${EMAIL_HTML_RULES}`),
-        text: z.string().optional().describe('Plain text content of the email'),
-        subject: z.string().optional().describe('Email subject'),
-        replyTo: z
-          .array(z.string())
-          .optional()
-          .describe('Reply-to email address(es)'),
-        previewText: z
-          .string()
-          .optional()
-          .describe('Preview text for the email'),
-      },
-    },
+    UPDATE_BROADCAST_TOOL,
     async ({
       broadcastId: rawBroadcastId,
       name,
@@ -760,49 +916,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'list-broadcast-clicked-links',
-    {
-      title: 'List Broadcast Clicked Links',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List the links clicked in a broadcast, ranked by total clicks.
-
-**Returns:** For each link: id (opaque pagination cursor for that row, not an entity id), url, clicks (total), unique_clicks. Use pagination (limit, after/before) for large lists.
-
-**When to use:**
-- User asks "what links were clicked in this broadcast?", "top clicked links", "click breakdown for this campaign"
-- Use get-broadcast for overall broadcast details; use this for per-link click data.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of links to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .trim()
-          .min(1)
-          .optional()
-          .describe(
-            'Cursor after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .trim()
-          .min(1)
-          .optional()
-          .describe(
-            'Cursor before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_BROADCAST_CLICKED_LINKS_TOOL,
     async ({ broadcastId: rawBroadcastId, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -871,70 +985,7 @@ export function addBroadcastTools(
 
   server.registerTool(
     'list-broadcast-recipients',
-    {
-      title: 'List Broadcast Recipients',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List the individual recipients of a broadcast for a given event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed).
-
-**NOT for:** Aggregate broadcast performance (use get-broadcast). Not for listing broadcasts themselves (use list-broadcasts). This tool returns per-recipient rows, one per contact per event type.
-
-**Returns:** For each recipient: email, id (opaque pagination cursor), contact_id (when known). Also includes count for "opened"/"clicked", bounce_type for "bounced", and clicked_links (url + click count) for "clicked". Use pagination (limit, after/before) for large lists.
-
-**When to use:** User asks "who opened this broadcast?", "who bounced?", "who clicked this link?", "who unsubscribed from this campaign?", or wants the list of contacts behind a specific broadcast engagement metric. Use get-broadcast first if you need the broadcast ID from a name.`,
-      inputSchema: {
-        broadcastId: z
-          .string()
-          .nonempty()
-          .describe(
-            'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
-          ),
-        type: z
-          .enum([
-            'sent',
-            'delivered',
-            'opened',
-            'clicked',
-            'bounced',
-            'complained',
-            'unsubscribed',
-            'suppressed',
-          ])
-          .describe('Recipient event type to list recipients for.'),
-        email: z
-          .string()
-          .optional()
-          .describe('Filter recipients by a substring of their email address.'),
-        bounceType: z
-          .enum(['permanent', 'transient', 'undetermined'])
-          .optional()
-          .describe(
-            'Filter by bounce type. Only meaningful when "type" is "bounced".',
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of recipients to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .nonempty()
-          .optional()
-          .describe(
-            'Cursor to fetch the page after this recipient (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .nonempty()
-          .optional()
-          .describe(
-            'Cursor to fetch the page before this recipient (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_BROADCAST_RECIPIENTS_TOOL,
     async ({
       broadcastId: rawBroadcastId,
       type,

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -5,11 +5,6 @@ import { EMAIL_HTML_RULES } from '../lib/email-html-rules.js';
 import type { ResendEditorClient } from '../lib/resend-editor-client.js';
 import { extractIdFromUrl } from '../lib/url-parser.js';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_BROADCAST_TOOL_BASE = {
   title: 'Create Broadcast',
   description: `**Purpose:** Create a broadcast campaign (one email sent to an entire segment). Defines subject, body, and segment; does NOT send yet. Use send-broadcast to send it.
@@ -32,11 +27,6 @@ const CREATE_BROADCAST_TOOL_BASE = {
 - **update-broadcast with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
 } as const;
 
-// create-broadcast's inputSchema shape genuinely depends on senderEmailAddress /
-// replierEmailAddresses (server-wide config, fixed for the process's
-// lifetime — passed once into runHttp() at boot, never per-request). Cache
-// by that config instead of rebuilding on every request; in practice this is
-// a cache hit after the very first call.
 let cachedCreateBroadcastSchemaKey: string | undefined;
 let cachedCreateBroadcastInputSchema: ReturnType<
   typeof buildCreateBroadcastInputSchema

--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -3,101 +3,151 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-export function addContactImportTools(server: McpServer, resend: Resend) {
-  server.registerTool(
-    'create-contact-import',
-    {
-      title: 'Create Contact Import',
-      description:
-        'Bulk-import contacts from a CSV file into Resend. The import is processed asynchronously: this returns an import ID immediately, then use get-contact-import to poll its status and counts. Provide the CSV via exactly one of `filePath`, `content`, or `url`. Max file size 100MB.',
-      inputSchema: {
-        filePath: z
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_CONTACT_IMPORT_TOOL = {
+  title: 'Create Contact Import',
+  description:
+    'Bulk-import contacts from a CSV file into Resend. The import is processed asynchronously: this returns an import ID immediately, then use get-contact-import to poll its status and counts. Provide the CSV via exactly one of `filePath`, `content`, or `url`. Max file size 100MB.',
+  inputSchema: {
+    filePath: z
+      .string()
+      .optional()
+      .describe(
+        'Local path to a CSV file to read and upload. Use one of filePath, content, or url.',
+      ),
+    content: z
+      .string()
+      .optional()
+      .describe(
+        'Raw CSV text to upload (e.g. "email,first_name\\na@b.com,Ada"). Use one of filePath, content, or url.',
+      ),
+    url: z
+      .string()
+      .optional()
+      .describe(
+        'URL of a CSV file to fetch and upload. Use one of filePath, content, or url.',
+      ),
+    filename: z
+      .string()
+      .optional()
+      .describe('Name for the uploaded file. Defaults to "contacts.csv".'),
+    columnMap: z
+      .object({
+        email: z
           .string()
           .optional()
-          .describe(
-            'Local path to a CSV file to read and upload. Use one of filePath, content, or url.',
-          ),
-        content: z
+          .describe('CSV header name that contains email addresses.'),
+        firstName: z
           .string()
           .optional()
-          .describe(
-            'Raw CSV text to upload (e.g. "email,first_name\\na@b.com,Ada"). Use one of filePath, content, or url.',
-          ),
-        url: z
+          .describe('CSV header name that contains first names.'),
+        lastName: z
           .string()
           .optional()
-          .describe(
-            'URL of a CSV file to fetch and upload. Use one of filePath, content, or url.',
-          ),
-        filename: z
+          .describe('CSV header name that contains last names.'),
+        unsubscribed: z
           .string()
           .optional()
-          .describe('Name for the uploaded file. Defaults to "contacts.csv".'),
-        columnMap: z
-          .object({
-            email: z
-              .string()
-              .optional()
-              .describe('CSV header name that contains email addresses.'),
-            firstName: z
-              .string()
-              .optional()
-              .describe('CSV header name that contains first names.'),
-            lastName: z
-              .string()
-              .optional()
-              .describe('CSV header name that contains last names.'),
-            unsubscribed: z
-              .string()
-              .optional()
-              .describe('CSV header name that contains the unsubscribed flag.'),
-            properties: z
-              .record(
-                z.string(),
-                z.object({
-                  column: z
-                    .string()
-                    .describe('CSV header name to map to this property.'),
-                  type: z
-                    .enum(['string', 'number', 'boolean'])
-                    .optional()
-                    .describe('Property type. Defaults to "string".'),
-                }),
-              )
-              .optional()
-              .describe(
-                'Maps custom property keys to CSV columns (e.g. { "company_name": { "column": "Company" } }).',
-              ),
-          })
-          .optional()
-          .describe(
-            'Maps contact fields to CSV header names. When omitted, headers are matched case-sensitively to "email", "first_name", and "last_name".',
-          ),
-        onConflict: z
-          .enum(['upsert', 'skip'])
-          .optional()
-          .describe(
-            'How to handle contacts that already exist: "upsert" updates them, "skip" leaves them unchanged. Defaults to "upsert".',
-          ),
-        segmentIds: z
-          .array(z.string())
-          .optional()
-          .describe('Array of segment IDs to assign the imported contacts to.'),
-        topics: z
-          .array(
+          .describe('CSV header name that contains the unsubscribed flag.'),
+        properties: z
+          .record(
+            z.string(),
             z.object({
-              id: z.string().describe('Topic ID'),
-              subscription: z
-                .enum(['opt_in', 'opt_out'])
-                .describe('Subscription preference for this topic'),
+              column: z
+                .string()
+                .describe('CSV header name to map to this property.'),
+              type: z
+                .enum(['string', 'number', 'boolean'])
+                .optional()
+                .describe('Property type. Defaults to "string".'),
             }),
           )
           .optional()
           .describe(
-            'Topic subscription configurations applied to the imported contacts.',
+            'Maps custom property keys to CSV columns (e.g. { "company_name": { "column": "Company" } }).',
           ),
-      },
-    },
+      })
+      .optional()
+      .describe(
+        'Maps contact fields to CSV header names. When omitted, headers are matched case-sensitively to "email", "first_name", and "last_name".',
+      ),
+    onConflict: z
+      .enum(['upsert', 'skip'])
+      .optional()
+      .describe(
+        'How to handle contacts that already exist: "upsert" updates them, "skip" leaves them unchanged. Defaults to "upsert".',
+      ),
+    segmentIds: z
+      .array(z.string())
+      .optional()
+      .describe('Array of segment IDs to assign the imported contacts to.'),
+    topics: z
+      .array(
+        z.object({
+          id: z.string().describe('Topic ID'),
+          subscription: z
+            .enum(['opt_in', 'opt_out'])
+            .describe('Subscription preference for this topic'),
+        }),
+      )
+      .optional()
+      .describe(
+        'Topic subscription configurations applied to the imported contacts.',
+      ),
+  },
+} as const;
+
+const GET_CONTACT_IMPORT_TOOL = {
+  title: 'Get Contact Import',
+  annotations: { readOnlyHint: true },
+  description:
+    'Get the status and counts of a contact import by ID. Use after create-contact-import to track progress (queued, in_progress, completed, failed).',
+  inputSchema: {
+    id: z.string().describe('Contact import ID'),
+  },
+} as const;
+
+const LIST_CONTACT_IMPORTS_TOOL = {
+  title: 'List Contact Imports',
+  annotations: { readOnlyHint: true },
+  description:
+    'List contact imports from Resend. Optionally filter by status. Use to discover import IDs or review past imports.',
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of contact imports to retrieve. Default: 10, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Contact import ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Contact import ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+    status: z
+      .enum(['queued', 'in_progress', 'completed', 'failed'])
+      .optional()
+      .describe('Filter imports by status.'),
+  },
+} as const;
+
+export function addContactImportTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'create-contact-import',
+    CREATE_CONTACT_IMPORT_TOOL,
     async ({
       filePath,
       content,
@@ -166,15 +216,7 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-contact-import',
-    {
-      title: 'Get Contact Import',
-      annotations: { readOnlyHint: true },
-      description:
-        'Get the status and counts of a contact import by ID. Use after create-contact-import to track progress (queued, in_progress, completed, failed).',
-      inputSchema: {
-        id: z.string().describe('Contact import ID'),
-      },
-    },
+    GET_CONTACT_IMPORT_TOOL,
     async ({ id }) => {
       const response = await resend.contacts.imports.get(id);
 
@@ -211,38 +253,7 @@ export function addContactImportTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-contact-imports',
-    {
-      title: 'List Contact Imports',
-      annotations: { readOnlyHint: true },
-      description:
-        'List contact imports from Resend. Optionally filter by status. Use to discover import IDs or review past imports.',
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of contact imports to retrieve. Default: 10, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Contact import ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Contact import ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-        status: z
-          .enum(['queued', 'in_progress', 'completed', 'failed'])
-          .optional()
-          .describe('Filter imports by status.'),
-      },
-    },
+    LIST_CONTACT_IMPORTS_TOOL,
     async ({ limit, after, before, status }) => {
       if (after && before) {
         throw new Error(

--- a/src/tools/contactImports.ts
+++ b/src/tools/contactImports.ts
@@ -3,11 +3,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_CONTACT_IMPORT_TOOL = {
   title: 'Create Contact Import',
   description:

--- a/src/tools/contactProperties.ts
+++ b/src/tools/contactProperties.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_CONTACT_PROPERTY_TOOL = {
   title: 'Create Contact Property',
   description:

--- a/src/tools/contactProperties.ts
+++ b/src/tools/contactProperties.ts
@@ -2,31 +2,99 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_CONTACT_PROPERTY_TOOL = {
+  title: 'Create Contact Property',
+  description:
+    'Create a new contact property in Resend. A contact property is a custom attribute (e.g. "company_name", "plan_tier") that can be attached to contacts.',
+  inputSchema: {
+    key: z
+      .string()
+      .nonempty()
+      .describe(
+        'The property key. Max 50 characters, only alphanumeric characters and underscores allowed.',
+      ),
+    type: z
+      .enum(['string', 'number'])
+      .describe('The property type: "string" or "number".'),
+    fallbackValue: z
+      .union([z.string(), z.number()])
+      .optional()
+      .describe(
+        'Default value when the property is not set for a contact. Must match the specified type.',
+      ),
+  },
+} as const;
+
+const LIST_CONTACT_PROPERTIES_TOOL = {
+  title: 'List Contact Properties',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all contact properties from Resend. This tool is useful for getting property IDs and seeing which custom attributes are configured. If you need a contact property ID, you MUST use this tool to get all available properties and then ask the user to select the one they want. Don't bother telling the user the IDs or creation dates unless they ask for them.",
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of contact properties to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Contact property ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Contact property ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_CONTACT_PROPERTY_TOOL = {
+  title: 'Get Contact Property',
+  annotations: { readOnlyHint: true },
+  description: 'Get a contact property by ID from Resend.',
+  inputSchema: {
+    contactPropertyId: z.string().nonempty().describe('Contact property ID'),
+  },
+} as const;
+
+const UPDATE_CONTACT_PROPERTY_TOOL = {
+  title: 'Update Contact Property',
+  description:
+    'Update an existing contact property in Resend. Only the fallback value can be changed — the key and type cannot be modified after creation.',
+  inputSchema: {
+    contactPropertyId: z.string().nonempty().describe('Contact property ID'),
+    fallbackValue: z
+      .union([z.string(), z.number(), z.null()])
+      .describe(
+        'New default value for the property. Pass null to remove the fallback value. Must match the property type.',
+      ),
+  },
+} as const;
+
+const REMOVE_CONTACT_PROPERTY_TOOL = {
+  title: 'Remove Contact Property',
+  description:
+    'Remove a contact property by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this contact property. Reference the KEY of the property when double-checking, and warn the user that removing a contact property is irreversible and will remove the property from all contacts. You may only use this tool if the user explicitly confirms they want to remove the contact property after you double-check.',
+  inputSchema: {
+    contactPropertyId: z.string().nonempty().describe('Contact property ID'),
+  },
+} as const;
+
 export function addContactPropertyTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-contact-property',
-    {
-      title: 'Create Contact Property',
-      description:
-        'Create a new contact property in Resend. A contact property is a custom attribute (e.g. "company_name", "plan_tier") that can be attached to contacts.',
-      inputSchema: {
-        key: z
-          .string()
-          .nonempty()
-          .describe(
-            'The property key. Max 50 characters, only alphanumeric characters and underscores allowed.',
-          ),
-        type: z
-          .enum(['string', 'number'])
-          .describe('The property type: "string" or "number".'),
-        fallbackValue: z
-          .union([z.string(), z.number()])
-          .optional()
-          .describe(
-            'Default value when the property is not set for a contact. Must match the specified type.',
-          ),
-      },
-    },
+    CREATE_CONTACT_PROPERTY_TOOL,
     async ({ key, type, fallbackValue }) => {
       const response = await resend.contactProperties.create({
         key,
@@ -55,34 +123,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-contact-properties',
-    {
-      title: 'List Contact Properties',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all contact properties from Resend. This tool is useful for getting property IDs and seeing which custom attributes are configured. If you need a contact property ID, you MUST use this tool to get all available properties and then ask the user to select the one they want. Don't bother telling the user the IDs or creation dates unless they ask for them.",
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of contact properties to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Contact property ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Contact property ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_CONTACT_PROPERTIES_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -140,17 +181,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-contact-property',
-    {
-      title: 'Get Contact Property',
-      annotations: { readOnlyHint: true },
-      description: 'Get a contact property by ID from Resend.',
-      inputSchema: {
-        contactPropertyId: z
-          .string()
-          .nonempty()
-          .describe('Contact property ID'),
-      },
-    },
+    GET_CONTACT_PROPERTY_TOOL,
     async ({ contactPropertyId }) => {
       const response = await resend.contactProperties.get(contactPropertyId);
 
@@ -174,22 +205,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'update-contact-property',
-    {
-      title: 'Update Contact Property',
-      description:
-        'Update an existing contact property in Resend. Only the fallback value can be changed — the key and type cannot be modified after creation.',
-      inputSchema: {
-        contactPropertyId: z
-          .string()
-          .nonempty()
-          .describe('Contact property ID'),
-        fallbackValue: z
-          .union([z.string(), z.number(), z.null()])
-          .describe(
-            'New default value for the property. Pass null to remove the fallback value. Must match the property type.',
-          ),
-      },
-    },
+    UPDATE_CONTACT_PROPERTY_TOOL,
     async ({ contactPropertyId, fallbackValue }) => {
       const response = await resend.contactProperties.update({
         id: contactPropertyId,
@@ -213,17 +229,7 @@ export function addContactPropertyTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'remove-contact-property',
-    {
-      title: 'Remove Contact Property',
-      description:
-        'Remove a contact property by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this contact property. Reference the KEY of the property when double-checking, and warn the user that removing a contact property is irreversible and will remove the property from all contacts. You may only use this tool if the user explicitly confirms they want to remove the contact property after you double-check.',
-      inputSchema: {
-        contactPropertyId: z
-          .string()
-          .nonempty()
-          .describe('Contact property ID'),
-      },
-    },
+    REMOVE_CONTACT_PROPERTY_TOOL,
     async ({ contactPropertyId }) => {
       const response = await resend.contactProperties.remove(contactPropertyId);
 

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -7,44 +7,252 @@ import type {
 } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_CONTACT_TOOL = {
+  title: 'Create Contact',
+  description:
+    'Create a new contact in Resend. Optionally assign to segments and configure topic subscriptions.',
+  inputSchema: {
+    email: z.email().describe('Contact email address'),
+    firstName: z.string().optional().describe('Contact first name'),
+    lastName: z.string().optional().describe('Contact last name'),
+    unsubscribed: z
+      .boolean()
+      .optional()
+      .describe('Whether the contact is unsubscribed from all broadcasts'),
+    properties: z
+      .record(z.string(), z.union([z.string(), z.number(), z.null()]))
+      .optional()
+      .describe(
+        'Custom property key-value pairs for the contact (e.g. { "company_name": "Acme" })',
+      ),
+    segmentIds: z
+      .array(z.string())
+      .optional()
+      .describe('Array of segment IDs to assign this contact to'),
+    topics: z
+      .array(
+        z.object({
+          id: z.string().describe('Topic ID'),
+          subscription: z
+            .enum(['opt_in', 'opt_out'])
+            .describe('Subscription preference for this topic'),
+        }),
+      )
+      .optional()
+      .describe('Array of topic subscription configurations'),
+  },
+} as const;
+
+const LIST_CONTACTS_TOOL = {
+  title: 'List Contacts',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List contacts from Resend. Optionally filter by segment. Use to discover contact IDs or emails.
+
+**NOT for:** Listing segments (use list-segments). Not for listing sent emails (use list-emails) or broadcasts (use list-broadcasts).
+
+**Returns:** For each contact: id, email, first_name, last_name, unsubscribed, created_at.
+
+**When to use:** User asks "who's in this list?", "show contacts", "who did I add?" Don't bother telling the user the IDs, unsubscribe statuses, or creation dates unless they ask for them.`,
+  inputSchema: {
+    segmentId: z
+      .string()
+      .optional()
+      .describe(
+        'Segment ID to filter by. If provided, only contacts in this segment will be returned.',
+      ),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of contacts to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Contact ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Contact ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_CONTACT_TOOL = {
+  title: 'Get Contact',
+  annotations: { readOnlyHint: true },
+  description: 'Get a contact by ID or email from Resend.',
+  inputSchema: {
+    id: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+  },
+} as const;
+
+const UPDATE_CONTACT_TOOL = {
+  title: 'Update Contact',
+  description: 'Update a contact in Resend (by ID or email).',
+  inputSchema: {
+    id: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    firstName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Contact first name. Pass `null` to remove the contact's first name.",
+      ),
+    lastName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Contact last name. Pass `null` to remove the contact's last name.",
+      ),
+    unsubscribed: z
+      .boolean()
+      .optional()
+      .describe('Whether the contact is unsubscribed from all broadcasts'),
+    properties: z
+      .record(z.string(), z.union([z.string(), z.number(), z.null()]))
+      .optional()
+      .describe(
+        'Custom property key-value pairs to update (e.g. { "company_name": "Acme" })',
+      ),
+  },
+} as const;
+
+const REMOVE_CONTACT_TOOL = {
+  title: 'Remove Contact',
+  description:
+    "Remove a contact from Resend (by ID or email). Before using this tool, you MUST double-check with the user that they want to remove this contact. Reference the contact's name (if present) and email address when double-checking, and warn the user that removing a contact is irreversible. You may only use this tool if the user explicitly confirms they want to remove the contact after you double-check.",
+  inputSchema: {
+    id: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+  },
+} as const;
+
+const ADD_CONTACT_TO_SEGMENT_TOOL = {
+  title: 'Add Contact to Segment',
+  description: 'Add a contact to a segment in Resend (by contact ID or email).',
+  inputSchema: {
+    contactId: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    segmentId: z
+      .string()
+      .nonempty()
+      .describe('Segment ID to add the contact to'),
+  },
+} as const;
+
+const REMOVE_CONTACT_FROM_SEGMENT_TOOL = {
+  title: 'Remove Contact from Segment',
+  description:
+    'Remove a contact from a segment in Resend (by contact ID or email). Before using this tool, you MUST double-check with the user that they want to remove the contact from the segment.',
+  inputSchema: {
+    contactId: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    segmentId: z
+      .string()
+      .nonempty()
+      .describe('Segment ID to remove the contact from'),
+  },
+} as const;
+
+const LIST_CONTACT_SEGMENTS_TOOL = {
+  title: 'List Contact Segments',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all segments a contact belongs to in Resend (by contact ID or email). Don't bother telling the user the IDs or creation dates unless they ask for them.",
+  inputSchema: {
+    contactId: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of segments to retrieve. Max: 100, Min: 1. If omitted, all segments are returned.',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Segment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Segment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const LIST_CONTACT_TOPICS_TOOL = {
+  title: 'List Contact Topics',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all topic subscriptions for a contact in Resend (by contact ID or email). Don't bother telling the user the IDs unless they ask for them.",
+  inputSchema: {
+    id: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of topics to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Topic ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Topic ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const UPDATE_CONTACT_TOPICS_TOOL = {
+  title: 'Update Contact Topics',
+  description:
+    'Update topic subscriptions for a contact in Resend (by contact ID or email).',
+  inputSchema: {
+    id: z.string().optional().describe('Contact ID'),
+    email: z.email().optional().describe('Contact email address'),
+    topics: z
+      .array(
+        z.object({
+          id: z.string().describe('Topic ID'),
+          subscription: z
+            .enum(['opt_in', 'opt_out'])
+            .describe('Subscription preference for this topic'),
+        }),
+      )
+      .min(1)
+      .describe('Array of topic subscription configurations to update'),
+  },
+} as const;
+
 export function addContactTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-contact',
-    {
-      title: 'Create Contact',
-      description:
-        'Create a new contact in Resend. Optionally assign to segments and configure topic subscriptions.',
-      inputSchema: {
-        email: z.email().describe('Contact email address'),
-        firstName: z.string().optional().describe('Contact first name'),
-        lastName: z.string().optional().describe('Contact last name'),
-        unsubscribed: z
-          .boolean()
-          .optional()
-          .describe('Whether the contact is unsubscribed from all broadcasts'),
-        properties: z
-          .record(z.string(), z.union([z.string(), z.number(), z.null()]))
-          .optional()
-          .describe(
-            'Custom property key-value pairs for the contact (e.g. { "company_name": "Acme" })',
-          ),
-        segmentIds: z
-          .array(z.string())
-          .optional()
-          .describe('Array of segment IDs to assign this contact to'),
-        topics: z
-          .array(
-            z.object({
-              id: z.string().describe('Topic ID'),
-              subscription: z
-                .enum(['opt_in', 'opt_out'])
-                .describe('Subscription preference for this topic'),
-            }),
-          )
-          .optional()
-          .describe('Array of topic subscription configurations'),
-      },
-    },
+    CREATE_CONTACT_TOOL,
     async ({
       email,
       firstName,
@@ -82,45 +290,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-contacts',
-    {
-      title: 'List Contacts',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List contacts from Resend. Optionally filter by segment. Use to discover contact IDs or emails.
-
-**NOT for:** Listing segments (use list-segments). Not for listing sent emails (use list-emails) or broadcasts (use list-broadcasts).
-
-**Returns:** For each contact: id, email, first_name, last_name, unsubscribed, created_at.
-
-**When to use:** User asks "who's in this list?", "show contacts", "who did I add?" Don't bother telling the user the IDs, unsubscribe statuses, or creation dates unless they ask for them.`,
-      inputSchema: {
-        segmentId: z
-          .string()
-          .optional()
-          .describe(
-            'Segment ID to filter by. If provided, only contacts in this segment will be returned.',
-          ),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of contacts to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Contact ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Contact ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_CONTACTS_TOOL,
     async ({ segmentId, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -197,15 +367,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-contact',
-    {
-      title: 'Get Contact',
-      annotations: { readOnlyHint: true },
-      description: 'Get a contact by ID or email from Resend.',
-      inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-      },
-    },
+    GET_CONTACT_TOOL,
     async ({ id, email }) => {
       let response: GetContactResponse;
       if (id) {
@@ -253,38 +415,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'update-contact',
-    {
-      title: 'Update Contact',
-      description: 'Update a contact in Resend (by ID or email).',
-      inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        firstName: z
-          .string()
-          .nullable()
-          .optional()
-          .describe(
-            "Contact first name. Pass `null` to remove the contact's first name.",
-          ),
-        lastName: z
-          .string()
-          .nullable()
-          .optional()
-          .describe(
-            "Contact last name. Pass `null` to remove the contact's last name.",
-          ),
-        unsubscribed: z
-          .boolean()
-          .optional()
-          .describe('Whether the contact is unsubscribed from all broadcasts'),
-        properties: z
-          .record(z.string(), z.union([z.string(), z.number(), z.null()]))
-          .optional()
-          .describe(
-            'Custom property key-value pairs to update (e.g. { "company_name": "Acme" })',
-          ),
-      },
-    },
+    UPDATE_CONTACT_TOOL,
     async ({ id, email, firstName, lastName, unsubscribed, properties }) => {
       const commonOptions = {
         firstName,
@@ -322,15 +453,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'remove-contact',
-    {
-      title: 'Remove Contact',
-      description:
-        "Remove a contact from Resend (by ID or email). Before using this tool, you MUST double-check with the user that they want to remove this contact. Reference the contact's name (if present) and email address when double-checking, and warn the user that removing a contact is irreversible. You may only use this tool if the user explicitly confirms they want to remove the contact after you double-check.",
-      inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-      },
-    },
+    REMOVE_CONTACT_TOOL,
     async ({ id, email }) => {
       let response: RemoveContactsResponse;
       if (id) {
@@ -360,19 +483,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'add-contact-to-segment',
-    {
-      title: 'Add Contact to Segment',
-      description:
-        'Add a contact to a segment in Resend (by contact ID or email).',
-      inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        segmentId: z
-          .string()
-          .nonempty()
-          .describe('Segment ID to add the contact to'),
-      },
-    },
+    ADD_CONTACT_TO_SEGMENT_TOOL,
     async ({ contactId, email, segmentId }) => {
       let response;
       if (contactId) {
@@ -402,19 +513,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'remove-contact-from-segment',
-    {
-      title: 'Remove Contact from Segment',
-      description:
-        'Remove a contact from a segment in Resend (by contact ID or email). Before using this tool, you MUST double-check with the user that they want to remove the contact from the segment.',
-      inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        segmentId: z
-          .string()
-          .nonempty()
-          .describe('Segment ID to remove the contact from'),
-      },
-    },
+    REMOVE_CONTACT_FROM_SEGMENT_TOOL,
     async ({ contactId, email, segmentId }) => {
       let response;
       if (contactId) {
@@ -447,36 +546,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-contact-segments',
-    {
-      title: 'List Contact Segments',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all segments a contact belongs to in Resend (by contact ID or email). Don't bother telling the user the IDs or creation dates unless they ask for them.",
-      inputSchema: {
-        contactId: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of segments to retrieve. Max: 100, Min: 1. If omitted, all segments are returned.',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Segment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Segment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_CONTACT_SEGMENTS_TOOL,
     async ({ contactId, email, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -545,36 +615,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-contact-topics',
-    {
-      title: 'List Contact Topics',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all topic subscriptions for a contact in Resend (by contact ID or email). Don't bother telling the user the IDs unless they ask for them.",
-      inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of topics to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Topic ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Topic ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_CONTACT_TOPICS_TOOL,
     async ({ id, email, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -652,26 +693,7 @@ export function addContactTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'update-contact-topics',
-    {
-      title: 'Update Contact Topics',
-      description:
-        'Update topic subscriptions for a contact in Resend (by contact ID or email).',
-      inputSchema: {
-        id: z.string().optional().describe('Contact ID'),
-        email: z.email().optional().describe('Contact email address'),
-        topics: z
-          .array(
-            z.object({
-              id: z.string().describe('Topic ID'),
-              subscription: z
-                .enum(['opt_in', 'opt_out'])
-                .describe('Subscription preference for this topic'),
-            }),
-          )
-          .min(1)
-          .describe('Array of topic subscription configurations to update'),
-      },
-    },
+    UPDATE_CONTACT_TOPICS_TOOL,
     async ({ id, email, topics }) => {
       if (!id && !email) {
         throw new Error(

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -7,11 +7,6 @@ import type {
 } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_CONTACT_TOOL = {
   title: 'Create Contact',
   description:

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -32,11 +32,6 @@ function formatClaimRecord(record: {
   return `${record.type}:\n  Name: ${record.name}\n  Value: ${record.value}\n  TTL: ${record.ttl}`;
 }
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_DOMAIN_TOOL = {
   title: 'Create Domain',
   description:

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -32,63 +32,223 @@ function formatClaimRecord(record: {
   return `${record.type}:\n  Name: ${record.name}\n  Value: ${record.value}\n  TTL: ${record.ttl}`;
 }
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_DOMAIN_TOOL = {
+  title: 'Create Domain',
+  description:
+    'Create a new domain in Resend. Returns DNS records that must be configured with your DNS provider for verification. You MUST display the DNS records to the user so they can set them up.',
+  inputSchema: {
+    name: z.string().nonempty().describe('The domain name (e.g., example.com)'),
+    region: z
+      .enum(['us-east-1', 'eu-west-1', 'sa-east-1', 'ap-northeast-1'])
+      .optional()
+      .describe('Deployment region. Defaults to "us-east-1".'),
+    customReturnPath: z
+      .string()
+      .optional()
+      .describe('Subdomain for the Return-Path address. Defaults to "send".'),
+    openTracking: z
+      .boolean()
+      .optional()
+      .describe('Enable email open rate tracking.'),
+    clickTracking: z
+      .boolean()
+      .optional()
+      .describe('Enable click tracking in HTML emails.'),
+    tls: z
+      .enum(['opportunistic', 'enforced'])
+      .optional()
+      .describe(
+        'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails. Defaults to "opportunistic".',
+      ),
+    trackingSubdomain: z
+      .string()
+      .optional()
+      .describe(
+        'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
+      ),
+    capabilities: z
+      .object({
+        sending: z
+          .enum(['enabled', 'disabled'])
+          .optional()
+          .describe('Enable or disable sending. Defaults to "enabled".'),
+        receiving: z
+          .enum(['enabled', 'disabled'])
+          .optional()
+          .describe('Enable or disable receiving. Defaults to "disabled".'),
+      })
+      .optional()
+      .describe('Domain capabilities configuration.'),
+  },
+} as const;
+
+const LIST_DOMAINS_TOOL = {
+  title: 'List Domains',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all domains from Resend. Returns domain names, statuses, regions, and capabilities. Don't bother telling the user the IDs unless they ask for them.",
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of domains to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Domain ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Domain ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_DOMAIN_TOOL = {
+  title: 'Get Domain',
+  annotations: { readOnlyHint: true },
+  description:
+    'Get a domain by ID from Resend. Returns full domain details including DNS records needed for verification.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Domain ID'),
+  },
+} as const;
+
+const UPDATE_DOMAIN_TOOL = {
+  title: 'Update Domain',
+  description:
+    'Update an existing domain in Resend. Allows changing tracking settings, TLS mode, and capabilities.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Domain ID'),
+    clickTracking: z
+      .boolean()
+      .optional()
+      .describe('Track clicks within the body of each HTML email.'),
+    openTracking: z
+      .boolean()
+      .optional()
+      .describe('Track the open rate of each email.'),
+    tls: z
+      .enum(['opportunistic', 'enforced'])
+      .optional()
+      .describe(
+        'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails.',
+      ),
+    trackingSubdomain: z
+      .string()
+      .optional()
+      .describe(
+        'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
+      ),
+    capabilities: z
+      .object({
+        sending: z
+          .enum(['enabled', 'disabled'])
+          .optional()
+          .describe('Enable or disable sending.'),
+        receiving: z
+          .enum(['enabled', 'disabled'])
+          .optional()
+          .describe('Enable or disable receiving.'),
+      })
+      .optional()
+      .describe(
+        'Domain capabilities. At least one capability must remain enabled.',
+      ),
+  },
+} as const;
+
+const REMOVE_DOMAIN_TOOL = {
+  title: 'Remove Domain',
+  description:
+    'Remove a domain by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this domain. Reference the NAME of the domain when double-checking, and warn the user that removing a domain is irreversible and will stop all email sending/receiving for that domain. You may only use this tool if the user explicitly confirms they want to remove the domain after you double-check.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Domain ID'),
+  },
+} as const;
+
+const VERIFY_DOMAIN_TOOL = {
+  title: 'Verify Domain',
+  description:
+    'Trigger domain verification in Resend. This starts an asynchronous verification process that checks if the DNS records are correctly configured. The domain status will temporarily show as "pending" during verification.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Domain ID'),
+  },
+} as const;
+
+const CREATE_DOMAIN_CLAIM_TOOL = {
+  title: 'Create Domain Claim',
+  description:
+    'Start a claim for a domain another Resend account has already verified. The domain is recreated under your account with brand-new DKIM keys, so the previous account\'s DNS records cannot be reused. Returns a TXT record that MUST be added to your DNS to prove ownership. You MUST display the TXT record to the user. After they add it, use verify-domain-claim, then poll get-domain-claim until status is "completed".',
+  inputSchema: {
+    name: z
+      .string()
+      .nonempty()
+      .describe('The domain name to claim (e.g., example.com)'),
+    region: z
+      .enum(['us-east-1', 'eu-west-1', 'sa-east-1', 'ap-northeast-1'])
+      .optional()
+      .describe('Deployment region. Defaults to "us-east-1".'),
+    customReturnPath: z
+      .string()
+      .optional()
+      .describe('Subdomain for the Return-Path address. Defaults to "send".'),
+    openTracking: z
+      .boolean()
+      .optional()
+      .describe('Enable email open rate tracking.'),
+    clickTracking: z
+      .boolean()
+      .optional()
+      .describe('Enable click tracking in HTML emails.'),
+    trackingSubdomain: z
+      .string()
+      .optional()
+      .describe(
+        'Custom subdomain for tracking links (e.g., "track" for track.example.com).',
+      ),
+  },
+} as const;
+
+const GET_DOMAIN_CLAIM_TOOL = {
+  title: 'Get Domain Claim',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve the latest claim for a domain by its placeholder Domain ID (the domain_id from create-domain-claim). Returns claim status and the TXT record needed to prove ownership. Poll until status is "completed".',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe('The placeholder Domain ID created by the claim'),
+  },
+} as const;
+
+const VERIFY_DOMAIN_CLAIM_TOOL = {
+  title: 'Verify Domain Claim',
+  description:
+    'Trigger asynchronous DNS verification and ownership transfer for a domain claim, using the placeholder Domain ID. The claim stays "pending" while verification runs; poll get-domain-claim for status. Once "completed", the transferred domain has NEW DKIM records — fetch them with get-domain, add them to DNS, then run verify-domain.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe('The placeholder Domain ID created by the claim'),
+  },
+} as const;
+
 export function addDomainTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-domain',
-    {
-      title: 'Create Domain',
-      description:
-        'Create a new domain in Resend. Returns DNS records that must be configured with your DNS provider for verification. You MUST display the DNS records to the user so they can set them up.',
-      inputSchema: {
-        name: z
-          .string()
-          .nonempty()
-          .describe('The domain name (e.g., example.com)'),
-        region: z
-          .enum(['us-east-1', 'eu-west-1', 'sa-east-1', 'ap-northeast-1'])
-          .optional()
-          .describe('Deployment region. Defaults to "us-east-1".'),
-        customReturnPath: z
-          .string()
-          .optional()
-          .describe(
-            'Subdomain for the Return-Path address. Defaults to "send".',
-          ),
-        openTracking: z
-          .boolean()
-          .optional()
-          .describe('Enable email open rate tracking.'),
-        clickTracking: z
-          .boolean()
-          .optional()
-          .describe('Enable click tracking in HTML emails.'),
-        tls: z
-          .enum(['opportunistic', 'enforced'])
-          .optional()
-          .describe(
-            'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails. Defaults to "opportunistic".',
-          ),
-        trackingSubdomain: z
-          .string()
-          .optional()
-          .describe(
-            'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
-          ),
-        capabilities: z
-          .object({
-            sending: z
-              .enum(['enabled', 'disabled'])
-              .optional()
-              .describe('Enable or disable sending. Defaults to "enabled".'),
-            receiving: z
-              .enum(['enabled', 'disabled'])
-              .optional()
-              .describe('Enable or disable receiving. Defaults to "disabled".'),
-          })
-          .optional()
-          .describe('Domain capabilities configuration.'),
-      },
-    },
+    CREATE_DOMAIN_TOOL,
     async ({
       name,
       region,
@@ -139,34 +299,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-domains',
-    {
-      title: 'List Domains',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all domains from Resend. Returns domain names, statuses, regions, and capabilities. Don't bother telling the user the IDs unless they ask for them.",
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of domains to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Domain ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Domain ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_DOMAINS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -222,87 +355,33 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'get-domain',
-    {
-      title: 'Get Domain',
-      annotations: { readOnlyHint: true },
-      description:
-        'Get a domain by ID from Resend. Returns full domain details including DNS records needed for verification.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.domains.get(id);
+  server.registerTool('get-domain', GET_DOMAIN_TOOL, async ({ id }) => {
+    const response = await resend.domains.get(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to get domain: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to get domain: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      const domain = response.data;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nOpen Tracking: ${domain.open_tracking ?? false}\nClick Tracking: ${domain.click_tracking ?? false}${domain.tracking_subdomain ? `\nTracking Subdomain: ${domain.tracking_subdomain}` : ''}\nCreated at: ${domain.created_at}`,
-          },
-          {
-            type: 'text',
-            text: `DNS Records:\n\n${formatDnsRecords(domain.records)}`,
-          },
-        ],
-      };
-    },
-  );
+    const domain = response.data;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Name: ${domain.name}\nID: ${domain.id}\nStatus: ${domain.status}\nRegion: ${domain.region}\nSending: ${domain.capabilities?.sending ?? 'unknown'}\nReceiving: ${domain.capabilities?.receiving ?? 'unknown'}\nOpen Tracking: ${domain.open_tracking ?? false}\nClick Tracking: ${domain.click_tracking ?? false}${domain.tracking_subdomain ? `\nTracking Subdomain: ${domain.tracking_subdomain}` : ''}\nCreated at: ${domain.created_at}`,
+        },
+        {
+          type: 'text',
+          text: `DNS Records:\n\n${formatDnsRecords(domain.records)}`,
+        },
+      ],
+    };
+  });
 
   server.registerTool(
     'update-domain',
-    {
-      title: 'Update Domain',
-      description:
-        'Update an existing domain in Resend. Allows changing tracking settings, TLS mode, and capabilities.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
-        clickTracking: z
-          .boolean()
-          .optional()
-          .describe('Track clicks within the body of each HTML email.'),
-        openTracking: z
-          .boolean()
-          .optional()
-          .describe('Track the open rate of each email.'),
-        tls: z
-          .enum(['opportunistic', 'enforced'])
-          .optional()
-          .describe(
-            'TLS mode. "opportunistic" attempts secure connection with fallback. "enforced" requires TLS or fails.',
-          ),
-        trackingSubdomain: z
-          .string()
-          .optional()
-          .describe(
-            'Custom subdomain for tracking links (e.g., "track" for track.example.com). When set, click and open tracking URLs will use this subdomain instead of the default.',
-          ),
-        capabilities: z
-          .object({
-            sending: z
-              .enum(['enabled', 'disabled'])
-              .optional()
-              .describe('Enable or disable sending.'),
-            receiving: z
-              .enum(['enabled', 'disabled'])
-              .optional()
-              .describe('Enable or disable receiving.'),
-          })
-          .optional()
-          .describe(
-            'Domain capabilities. At least one capability must remain enabled.',
-          ),
-      },
-    },
+    UPDATE_DOMAIN_TOOL,
     async ({
       id,
       clickTracking,
@@ -335,102 +414,46 @@ export function addDomainTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'remove-domain',
-    {
-      title: 'Remove Domain',
-      description:
-        'Remove a domain by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this domain. Reference the NAME of the domain when double-checking, and warn the user that removing a domain is irreversible and will stop all email sending/receiving for that domain. You may only use this tool if the user explicitly confirms they want to remove the domain after you double-check.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.domains.remove(id);
+  server.registerTool('remove-domain', REMOVE_DOMAIN_TOOL, async ({ id }) => {
+    const response = await resend.domains.remove(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to remove domain: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to remove domain: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [
-          { type: 'text', text: 'Domain removed successfully.' },
-          { type: 'text', text: `ID: ${response.data.id}` },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        { type: 'text', text: 'Domain removed successfully.' },
+        { type: 'text', text: `ID: ${response.data.id}` },
+      ],
+    };
+  });
 
-  server.registerTool(
-    'verify-domain',
-    {
-      title: 'Verify Domain',
-      description:
-        'Trigger domain verification in Resend. This starts an asynchronous verification process that checks if the DNS records are correctly configured. The domain status will temporarily show as "pending" during verification.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Domain ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.domains.verify(id);
+  server.registerTool('verify-domain', VERIFY_DOMAIN_TOOL, async ({ id }) => {
+    const response = await resend.domains.verify(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to verify domain: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to verify domain: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: 'Domain verification started. The domain status will update once DNS records are verified.',
-          },
-          { type: 'text', text: `ID: ${response.data.id}` },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Domain verification started. The domain status will update once DNS records are verified.',
+        },
+        { type: 'text', text: `ID: ${response.data.id}` },
+      ],
+    };
+  });
 
   server.registerTool(
     'create-domain-claim',
-    {
-      title: 'Create Domain Claim',
-      description:
-        'Start a claim for a domain another Resend account has already verified. The domain is recreated under your account with brand-new DKIM keys, so the previous account\'s DNS records cannot be reused. Returns a TXT record that MUST be added to your DNS to prove ownership. You MUST display the TXT record to the user. After they add it, use verify-domain-claim, then poll get-domain-claim until status is "completed".',
-      inputSchema: {
-        name: z
-          .string()
-          .nonempty()
-          .describe('The domain name to claim (e.g., example.com)'),
-        region: z
-          .enum(['us-east-1', 'eu-west-1', 'sa-east-1', 'ap-northeast-1'])
-          .optional()
-          .describe('Deployment region. Defaults to "us-east-1".'),
-        customReturnPath: z
-          .string()
-          .optional()
-          .describe(
-            'Subdomain for the Return-Path address. Defaults to "send".',
-          ),
-        openTracking: z
-          .boolean()
-          .optional()
-          .describe('Enable email open rate tracking.'),
-        clickTracking: z
-          .boolean()
-          .optional()
-          .describe('Enable click tracking in HTML emails.'),
-        trackingSubdomain: z
-          .string()
-          .optional()
-          .describe(
-            'Custom subdomain for tracking links (e.g., "track" for track.example.com).',
-          ),
-      },
-    },
+    CREATE_DOMAIN_CLAIM_TOOL,
     async ({
       name,
       region,
@@ -475,18 +498,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-domain-claim',
-    {
-      title: 'Get Domain Claim',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve the latest claim for a domain by its placeholder Domain ID (the domain_id from create-domain-claim). Returns claim status and the TXT record needed to prove ownership. Poll until status is "completed".',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe('The placeholder Domain ID created by the claim'),
-      },
-    },
+    GET_DOMAIN_CLAIM_TOOL,
     async ({ id }) => {
       const response = await resend.domains.claims.get(id);
       if (response.error) {
@@ -512,17 +524,7 @@ export function addDomainTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'verify-domain-claim',
-    {
-      title: 'Verify Domain Claim',
-      description:
-        'Trigger asynchronous DNS verification and ownership transfer for a domain claim, using the placeholder Domain ID. The claim stays "pending" while verification runs; poll get-domain-claim for status. Once "completed", the transferred domain has NEW DKIM records — fetch them with get-domain, add them to DNS, then run verify-domain.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe('The placeholder Domain ID created by the claim'),
-      },
-    },
+    VERIFY_DOMAIN_CLAIM_TOOL,
     async ({ id }) => {
       const response = await resend.domains.claims.verify(id);
       if (response.error) {

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -11,11 +11,6 @@ interface EditorConnection {
   agent_name?: string;
 }
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const GET_TIPTAP_JSON_CONTENT_TOOL = {
   title: 'Get TipTap JSON Content',
   annotations: { readOnlyHint: true },

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -11,6 +11,78 @@ interface EditorConnection {
   agent_name?: string;
 }
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const GET_TIPTAP_JSON_CONTENT_TOOL = {
+  title: 'Get TipTap JSON Content',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** Retrieve the existing TipTap JSON content of a broadcast or template, optionally bundled with the TipTap schema reference. Also connects the agent to the editor so the avatar is visible while content is being generated.
+
+**When to use:**
+- **Always call this before compose-broadcast or compose-template** to fetch the current document state — even if you expect it to be empty, the resource may have content set via the dashboard
+- When the user asks to edit, tweak, or modify existing email content
+- To inspect the current TipTap structure of a resource
+
+**Returns:** The TipTap JSON content object for the resource, and optionally the TipTap schema. Use the content as the base for modifications, then pass the updated JSON to compose-broadcast or compose-template.
+
+**Note:** This tool automatically connects the agent to the editor. The subsequent compose-broadcast or compose-template call will disconnect when done.
+
+**Tip:** Set include_schema to true to get both the existing content and the schema in one call.`,
+  inputSchema: {
+    resource_type: z
+      .enum(['broadcast', 'template'])
+      .describe('Type of resource to fetch content for'),
+    resource_id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The broadcast ID (UUID), template identifier (UUID or alias), or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id> or https://resend.com/templates/<id>)',
+      ),
+    include_schema: z
+      .boolean()
+      .default(true)
+      .describe(
+        'Returns the TipTap schema reference alongside the content. Required for producing valid TipTap JSON. Set to false only if you already have the schema.',
+      ),
+  },
+} as const;
+
+const CONNECT_TO_EDITOR_TOOL = {
+  title: 'Connect to Editor',
+  description: `**Purpose:** Show agent presence in the Resend dashboard editor. Users will see an agent avatar while connected.
+
+**When to use:**
+- To signal to dashboard users that an AI agent is working on the content outside of compose workflows
+- **Not needed before compose-broadcast or compose-template** — get-tiptap-json-content connects automatically, and compose tools disconnect when done.
+
+**Returns:** Connection token and room ID.`,
+  inputSchema: {
+    resource_type: z
+      .enum(['broadcast', 'template'])
+      .describe('Type of resource to connect to'),
+    resource_id: z
+      .string()
+      .nonempty()
+      .describe(
+        'ID of the resource or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id> or https://resend.com/templates/<id>)',
+      ),
+    agent_name: z
+      .string()
+      .optional()
+      .describe('Display name for the agent avatar'),
+  },
+} as const;
+
+const DISCONNECT_FROM_EDITOR_TOOL = {
+  title: 'Disconnect from Editor',
+  description:
+    'Remove agent presence from the Resend dashboard editor. Call this when done editing.',
+  inputSchema: {},
+} as const;
+
 export function addEditorTools(
   server: McpServer,
   dashboard: DashboardClient,
@@ -71,39 +143,7 @@ export function addEditorTools(
 
   server.registerTool(
     'get-tiptap-json-content',
-    {
-      title: 'Get TipTap JSON Content',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** Retrieve the existing TipTap JSON content of a broadcast or template, optionally bundled with the TipTap schema reference. Also connects the agent to the editor so the avatar is visible while content is being generated.
-
-**When to use:**
-- **Always call this before compose-broadcast or compose-template** to fetch the current document state — even if you expect it to be empty, the resource may have content set via the dashboard
-- When the user asks to edit, tweak, or modify existing email content
-- To inspect the current TipTap structure of a resource
-
-**Returns:** The TipTap JSON content object for the resource, and optionally the TipTap schema. Use the content as the base for modifications, then pass the updated JSON to compose-broadcast or compose-template.
-
-**Note:** This tool automatically connects the agent to the editor. The subsequent compose-broadcast or compose-template call will disconnect when done.
-
-**Tip:** Set include_schema to true to get both the existing content and the schema in one call.`,
-      inputSchema: {
-        resource_type: z
-          .enum(['broadcast', 'template'])
-          .describe('Type of resource to fetch content for'),
-        resource_id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The broadcast ID (UUID), template identifier (UUID or alias), or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id> or https://resend.com/templates/<id>)',
-          ),
-        include_schema: z
-          .boolean()
-          .default(true)
-          .describe(
-            'Returns the TipTap schema reference alongside the content. Required for producing valid TipTap JSON. Set to false only if you already have the schema.',
-          ),
-      },
-    },
+    GET_TIPTAP_JSON_CONTENT_TOOL,
     async (
       { resource_type, resource_id: rawResourceId, include_schema },
       ctx,
@@ -167,31 +207,7 @@ export function addEditorTools(
 
   server.registerTool(
     'connect-to-editor',
-    {
-      title: 'Connect to Editor',
-      description: `**Purpose:** Show agent presence in the Resend dashboard editor. Users will see an agent avatar while connected.
-
-**When to use:**
-- To signal to dashboard users that an AI agent is working on the content outside of compose workflows
-- **Not needed before compose-broadcast or compose-template** — get-tiptap-json-content connects automatically, and compose tools disconnect when done.
-
-**Returns:** Connection token and room ID.`,
-      inputSchema: {
-        resource_type: z
-          .enum(['broadcast', 'template'])
-          .describe('Type of resource to connect to'),
-        resource_id: z
-          .string()
-          .nonempty()
-          .describe(
-            'ID of the resource or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id> or https://resend.com/templates/<id>)',
-          ),
-        agent_name: z
-          .string()
-          .optional()
-          .describe('Display name for the agent avatar'),
-      },
-    },
+    CONNECT_TO_EDITOR_TOOL,
     async ({ resource_type, resource_id: rawResourceId, agent_name }, ctx) => {
       if (!apiClient) {
         throw new Error('API client not configured. Provide a Resend API key.');
@@ -228,12 +244,7 @@ export function addEditorTools(
 
   server.registerTool(
     'disconnect-from-editor',
-    {
-      title: 'Disconnect from Editor',
-      description:
-        'Remove agent presence from the Resend dashboard editor. Call this when done editing.',
-      inputSchema: {},
-    },
+    DISCONNECT_FROM_EDITOR_TOOL,
     async (_args, _ctx) => {
       if (!apiClient) {
         throw new Error('API client not configured. Provide a Resend API key.');

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -3,11 +3,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const SEND_EMAIL_TOOL_BASE = {
   title: 'Send Email',
   description: `**Purpose:** Send a single transactional email to one or more recipients immediately (or schedule it). Use for one-off messages, notifications, and direct replies.
@@ -27,11 +22,6 @@ const SEND_EMAIL_TOOL_BASE = {
 **Key trigger phrases:** "Send an email", "Email this to", "Notify", "Send a message", "Reply to them", "Schedule an email"`,
 } as const;
 
-// send-email's inputSchema shape genuinely depends on senderEmailAddress /
-// replierEmailAddresses (server-wide config, fixed for the process's
-// lifetime — passed once into runHttp() at boot, never per-request). Cache
-// by that config instead of rebuilding on every request; in practice this is
-// a cache hit after the very first call.
 let cachedSendEmailSchemaKey: string | undefined;
 let cachedSendEmailInputSchema: ReturnType<typeof buildSendEmailInputSchema>;
 

--- a/src/tools/emails.ts
+++ b/src/tools/emails.ts
@@ -3,22 +3,14 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-export function addEmailTools(
-  server: McpServer,
-  resend: Resend,
-  {
-    senderEmailAddress,
-    replierEmailAddresses,
-  }: {
-    senderEmailAddress?: string;
-    replierEmailAddresses: string[];
-  },
-) {
-  server.registerTool(
-    'send-email',
-    {
-      title: 'Send Email',
-      description: `**Purpose:** Send a single transactional email to one or more recipients immediately (or schedule it). Use for one-off messages, notifications, and direct replies.
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const SEND_EMAIL_TOOL_BASE = {
+  title: 'Send Email',
+  description: `**Purpose:** Send a single transactional email to one or more recipients immediately (or schedule it). Use for one-off messages, notifications, and direct replies.
 
 **NOT for:** Sending the same email to a whole list/audience (use create-broadcast + send-broadcast). Not for managing contacts or audiences.
 
@@ -33,131 +25,545 @@ export function addEmailTools(
 **Workflow:** Get recipient(s) and content from user → send-email. Use list-emails or get-email to check delivery status afterward.
 
 **Key trigger phrases:** "Send an email", "Email this to", "Notify", "Send a message", "Reply to them", "Schedule an email"`,
-      inputSchema: {
-        to: z
-          .array(z.email())
-          .min(1)
-          .max(50)
-          .describe('Array of recipient email addresses (1-50 recipients)'),
-        subject: z.string().describe('Email subject line'),
-        text: z.string().describe('Plain text email content'),
-        html: z
-          .string()
-          .optional()
-          .describe(
-            'HTML email content. When provided, the plain text argument MUST be provided as well.',
-          ),
-        cc: z
-          .array(z.email())
-          .optional()
-          .describe(
-            'Optional array of CC email addresses. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
-          ),
-        bcc: z
-          .array(z.email())
-          .optional()
-          .describe(
-            'Optional array of BCC email addresses. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
-          ),
-        scheduledAt: z
-          .string()
-          .optional()
-          .describe(
-            "Optional parameter to schedule the email. This uses natural language. Examples would be 'tomorrow at 10am' or 'in 2 hours' or 'next day at 9am PST' or 'Friday at 3pm ET'.",
-          ),
-        attachments: z
-          .array(
-            z.object({
-              filename: z
-                .string()
-                .describe(
-                  'Name of the file with extension (e.g., "report.pdf")',
-                ),
-              filePath: z
-                .string()
-                .optional()
-                .describe('Local file path to read and attach'),
-              url: z
-                .string()
-                .optional()
-                .describe(
-                  'URL where the file is hosted (Resend will fetch it)',
-                ),
-              content: z
-                .string()
-                .optional()
-                .describe('Base64-encoded file content'),
-              contentType: z
-                .string()
-                .optional()
-                .describe(
-                  'MIME type (e.g., "application/pdf"). Auto-derived from filename if not set',
-                ),
-              contentId: z
-                .string()
-                .optional()
-                .describe(
-                  'Content ID for inline images. Reference in HTML with cid:<contentId>',
-                ),
-            }),
-          )
-          .optional()
-          .describe(
-            'Array of file attachments. Each needs filename plus one of: filePath, url, or content. Max 40MB total.',
-          ),
-        tags: z
-          .array(
-            z.object({
-              name: z.string().describe('Tag name (key)'),
-              value: z.string().describe('Tag value'),
-            }),
-          )
-          .optional()
-          .describe(
-            'Array of custom tags for tracking/analytics. Each tag has a name and value.',
-          ),
-        topicId: z
-          .string()
-          .optional()
-          .describe(
-            'Topic ID for subscription-based sending. When set, the email respects contact subscription preferences for this topic.',
-          ),
-        headers: z
-          .record(z.string(), z.string())
-          .optional()
-          .describe(
-            'Optional custom email headers as key/value pairs (e.g. {"List-Unsubscribe": "<https://example.com/unsubscribe>", "X-Entity-Ref-ID": "unique-id"}). Use for one-click unsubscribe, preventing Gmail threading, or other MIME headers Resend accepts.',
-          ),
-        idempotencyKey: z
-          .string()
-          .min(1)
-          .max(256)
-          .optional()
-          .describe(
-            'Optional unique key that prevents duplicate sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same logical email; use a new key for a different email. Must be 1-256 characters.',
-          ),
-        // If sender email address is not provided, the tool requires it as an argument
-        ...(!senderEmailAddress
-          ? {
-              from: z
-                .string()
-                .nonempty()
-                .describe(
-                  'Sender email address (e.g. "onboarding@resend.com" or "Acme <onboarding@resend.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
-                ),
-            }
-          : {}),
-        ...(replierEmailAddresses.length === 0
-          ? {
-              replyTo: z
-                .array(z.string())
-                .optional()
-                .describe(
-                  'Optional email addresses for the email readers to reply to (e.g. "support@example.com" or "Support Team <support@example.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
-                ),
-            }
-          : {}),
-      },
+} as const;
+
+// send-email's inputSchema shape genuinely depends on senderEmailAddress /
+// replierEmailAddresses (server-wide config, fixed for the process's
+// lifetime — passed once into runHttp() at boot, never per-request). Cache
+// by that config instead of rebuilding on every request; in practice this is
+// a cache hit after the very first call.
+let cachedSendEmailSchemaKey: string | undefined;
+let cachedSendEmailInputSchema: ReturnType<typeof buildSendEmailInputSchema>;
+
+function buildSendEmailInputSchema(
+  senderEmailAddress: string | undefined,
+  replierEmailAddresses: string[],
+) {
+  return {
+    to: z
+      .array(z.email())
+      .min(1)
+      .max(50)
+      .describe('Array of recipient email addresses (1-50 recipients)'),
+    subject: z.string().describe('Email subject line'),
+    text: z.string().describe('Plain text email content'),
+    html: z
+      .string()
+      .optional()
+      .describe(
+        'HTML email content. When provided, the plain text argument MUST be provided as well.',
+      ),
+    cc: z
+      .array(z.email())
+      .optional()
+      .describe(
+        'Optional array of CC email addresses. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+      ),
+    bcc: z
+      .array(z.email())
+      .optional()
+      .describe(
+        'Optional array of BCC email addresses. You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+      ),
+    scheduledAt: z
+      .string()
+      .optional()
+      .describe(
+        "Optional parameter to schedule the email. This uses natural language. Examples would be 'tomorrow at 10am' or 'in 2 hours' or 'next day at 9am PST' or 'Friday at 3pm ET'.",
+      ),
+    attachments: z
+      .array(
+        z.object({
+          filename: z
+            .string()
+            .describe('Name of the file with extension (e.g., "report.pdf")'),
+          filePath: z
+            .string()
+            .optional()
+            .describe('Local file path to read and attach'),
+          url: z
+            .string()
+            .optional()
+            .describe('URL where the file is hosted (Resend will fetch it)'),
+          content: z
+            .string()
+            .optional()
+            .describe('Base64-encoded file content'),
+          contentType: z
+            .string()
+            .optional()
+            .describe(
+              'MIME type (e.g., "application/pdf"). Auto-derived from filename if not set',
+            ),
+          contentId: z
+            .string()
+            .optional()
+            .describe(
+              'Content ID for inline images. Reference in HTML with cid:<contentId>',
+            ),
+        }),
+      )
+      .optional()
+      .describe(
+        'Array of file attachments. Each needs filename plus one of: filePath, url, or content. Max 40MB total.',
+      ),
+    tags: z
+      .array(
+        z.object({
+          name: z.string().describe('Tag name (key)'),
+          value: z.string().describe('Tag value'),
+        }),
+      )
+      .optional()
+      .describe(
+        'Array of custom tags for tracking/analytics. Each tag has a name and value.',
+      ),
+    topicId: z
+      .string()
+      .optional()
+      .describe(
+        'Topic ID for subscription-based sending. When set, the email respects contact subscription preferences for this topic.',
+      ),
+    headers: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe(
+        'Optional custom email headers as key/value pairs (e.g. {"List-Unsubscribe": "<https://example.com/unsubscribe>", "X-Entity-Ref-ID": "unique-id"}). Use for one-click unsubscribe, preventing Gmail threading, or other MIME headers Resend accepts.',
+      ),
+    idempotencyKey: z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Optional unique key that prevents duplicate sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same logical email; use a new key for a different email. Must be 1-256 characters.',
+      ),
+    // If sender email address is not provided, the tool requires it as an argument
+    ...(!senderEmailAddress
+      ? {
+          from: z
+            .string()
+            .nonempty()
+            .describe(
+              'Sender email address (e.g. "onboarding@resend.com" or "Acme <onboarding@resend.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+            ),
+        }
+      : {}),
+    ...(replierEmailAddresses.length === 0
+      ? {
+          replyTo: z
+            .array(z.string())
+            .optional()
+            .describe(
+              'Optional email addresses for the email readers to reply to (e.g. "support@example.com" or "Support Team <support@example.com>"). You MUST ask the user for this parameter. Under no circumstance provide it yourself',
+            ),
+        }
+      : {}),
+  };
+}
+
+function getSendEmailInputSchema(
+  senderEmailAddress: string | undefined,
+  replierEmailAddresses: string[],
+) {
+  const key = `${senderEmailAddress ?? ''}|${replierEmailAddresses.join(',')}`;
+  if (cachedSendEmailSchemaKey !== key) {
+    cachedSendEmailInputSchema = buildSendEmailInputSchema(
+      senderEmailAddress,
+      replierEmailAddresses,
+    );
+    cachedSendEmailSchemaKey = key;
+  }
+  return cachedSendEmailInputSchema;
+}
+
+const LIST_EMAILS_TOOL = {
+  title: 'List Emails',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List recently sent emails (transactional emails sent via send-email) with metadata: recipient, subject, status, timestamps.
+
+**NOT for:** Listing broadcast campaigns (use list-broadcasts). Not for composing or sending.
+
+**Returns:** Paginated list with to, subject, status, created_at, message_id, and ID per email.
+
+**When to use:**
+- User asks "what emails were sent?", "show recent emails", "did my email go out?"
+- Checking delivery status of sent messages
+- Finding an email ID to fetch full content (then use get-email)
+
+**Workflow:** list-emails → get-email( id ) when user needs full body or details.`,
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of emails to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Email ID after which to retrieve more emails (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Email ID before which to retrieve more emails (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_EMAIL_TOOL = {
+  title: 'Get Email',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve full details of a specific sent transactional email by ID, including message_id, HTML and plain text content.',
+  inputSchema: {
+    id: z.string().describe('The email ID to retrieve'),
+  },
+} as const;
+
+const LIST_RECEIVED_EMAILS_TOOL = {
+  title: 'List Received Emails',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List emails received (inbox) by your Resend receiving address. Use for "show my inbox", "what emails did I get?", "list incoming mail".
+
+**NOT for:** Listing emails you sent (use list-emails). Not for listing broadcasts (use list-broadcasts).
+
+**Returns:** Paginated metadata: from, to, subject, message_id, received time. Use get-received-email with an ID for full content.`,
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of emails to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Email ID after which to retrieve more emails (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Email ID before which to retrieve more emails (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_RECEIVED_EMAIL_TOOL = {
+  title: 'Get Received Email',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve full details of a specific received email by ID, including HTML and plain text content, headers, and raw email download URL.',
+  inputSchema: {
+    id: z.string().describe('The received email ID to retrieve'),
+  },
+} as const;
+
+const LIST_RECEIVED_EMAIL_ATTACHMENTS_TOOL = {
+  title: 'List Received Email Attachments',
+  annotations: { readOnlyHint: true },
+  description:
+    'List all attachments from a specific received (inbox) email. Returns attachment metadata including filename, size, content type, and a time-limited download URL. Use for emails listed by list-received-emails.',
+  inputSchema: {
+    emailId: z.string().describe('The received email ID'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of attachments to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Attachment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Attachment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_RECEIVED_EMAIL_ATTACHMENT_TOOL = {
+  title: 'Get Received Email Attachment',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve details of a specific attachment from a received email, including a time-limited download URL.',
+  inputSchema: {
+    emailId: z.string().describe('The received email ID'),
+    id: z.string().describe('The attachment ID'),
+  },
+} as const;
+
+const CANCEL_EMAIL_TOOL = {
+  title: 'Cancel Email',
+  description:
+    'Cancel a scheduled email that has not yet been sent. Only works for emails that were scheduled using the scheduledAt parameter.',
+  inputSchema: {
+    id: z.string().describe('The ID of the scheduled email to cancel'),
+  },
+} as const;
+
+const UPDATE_EMAIL_TOOL = {
+  title: 'Update Email',
+  description:
+    'Reschedule a scheduled email by updating its scheduled send time. Only works for emails that were scheduled and have not yet been sent.',
+  inputSchema: {
+    id: z.string().describe('The ID of the scheduled email to update'),
+    scheduledAt: z
+      .string()
+      .describe(
+        'The new scheduled time in ISO 8601 format (e.g., "2024-08-05T11:52:01.858Z").',
+      ),
+  },
+} as const;
+
+const SHARE_EMAIL_TOOL = {
+  title: 'Share Email',
+  description:
+    'Create a shareable link for a sent or received email, so anyone with the link can view it without Resend dashboard access. Works for any email ID, sent or received.',
+  inputSchema: {
+    id: z.string().describe('The ID of the sent or received email to share'),
+    expiresIn: z
+      .string()
+      .optional()
+      .describe(
+        'How long the share link stays valid, as a human-readable duration (e.g. "10m", "2 hours", "1 day", "1h 30m"). Defaults to 48 hours; capped at 48 hours.',
+      ),
+  },
+} as const;
+
+const GET_EMAIL_METRICS_TOOL = {
+  title: 'Email Metrics',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve account-level email delivery and engagement metrics (sent, delivered, bounced, opened, clicked, etc.) for a date range, optionally broken down by period, domain, email, or broadcast.',
+  inputSchema: {
+    startDate: z
+      .string()
+      .optional()
+      .describe(
+        'Start of the date range, as an ISO 8601 date or datetime. Defaults to 6 days before endDate.',
+      ),
+    endDate: z
+      .string()
+      .optional()
+      .describe(
+        'End of the date range, as an ISO 8601 date or datetime. Defaults to now.',
+      ),
+    timezone: z
+      .string()
+      .optional()
+      .describe(
+        'IANA timezone (e.g. "America/New_York") used to bucket periods when "period" is in dimensions. Defaults to UTC.',
+      ),
+    granularity: z
+      .enum(['hourly', 'daily', 'weekly', 'monthly'])
+      .optional()
+      .describe(
+        'Bucket size used when "period" is in dimensions. Defaults to "daily".',
+      ),
+    metrics: z
+      .array(
+        z.enum([
+          'received',
+          'delivered',
+          'complained',
+          'suppressed',
+          'bounced',
+          'bounced_transient',
+          'bounced_permanent',
+          'bounced_undetermined',
+          'opened',
+          'clicked',
+          'unsubscribed',
+          'delivery_delayed',
+          'failed',
+          'sent',
+          'unique_opened',
+          'unique_clicked',
+          'delivery_rate',
+          'open_rate',
+          'click_rate',
+          'bounce_rate',
+          'complaint_rate',
+          'unsubscribe_rate',
+        ]),
+      )
+      .optional()
+      .describe('Metrics to include in the response. Defaults to all metrics.'),
+    dimensions: z
+      .array(z.enum(['period', 'domain', 'email', 'broadcast']))
+      .optional()
+      .describe(
+        'Dimensions to break the response down by. "email" and "broadcast" cannot be combined. Defaults to none, which returns totals only.',
+      ),
+    domainId: z
+      .array(z.uuid())
+      .max(100)
+      .optional()
+      .describe('Restrict the response to these sending domain IDs (max 100).'),
+    emailId: z
+      .array(z.uuid())
+      .max(100)
+      .optional()
+      .describe(
+        'Restrict the response to these email IDs (max 100). Cannot be combined with the "broadcast" dimension or broadcastId.',
+      ),
+    broadcastId: z
+      .array(z.uuid())
+      .max(100)
+      .optional()
+      .describe(
+        'Restrict the response to these broadcast IDs (max 100). Cannot be combined with the "email" dimension or emailId.',
+      ),
+  },
+} as const;
+
+const LIST_SENT_EMAIL_ATTACHMENTS_TOOL = {
+  title: 'List Sent Email Attachments',
+  annotations: { readOnlyHint: true },
+  description:
+    'List all attachments from a specific sent email (from send-email or list-emails). Returns attachment metadata including filename, size, content type, and a time-limited download URL.',
+  inputSchema: {
+    emailId: z.string().describe('The sent email ID'),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of attachments to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Attachment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Attachment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_SENT_EMAIL_ATTACHMENT_TOOL = {
+  title: 'Get Sent Email Attachment',
+  annotations: { readOnlyHint: true },
+  description:
+    'Retrieve details of a specific attachment from a sent email, including a time-limited download URL.',
+  inputSchema: {
+    emailId: z.string().describe('The sent email ID'),
+    id: z.string().describe('The attachment ID'),
+  },
+} as const;
+
+const SEND_BATCH_EMAILS_TOOL = {
+  title: 'Send Batch Emails',
+  description: `**Purpose:** Send up to 100 transactional emails in one API call. Each item has the same fields as send-email (to, subject, text, from, etc.).
+
+**NOT for:** Sending one email (use send-email) or the same content to a segment (use create-broadcast + send-broadcast).
+
+**When to use:** User wants to send many individual emails in bulk (e.g. 50 password resets, 100 receipts). Not for one-to-many broadcasts.`,
+  inputSchema: {
+    emails: z
+      .array(
+        z.object({
+          to: z
+            .array(z.email())
+            .min(1)
+            .max(50)
+            .describe('Array of recipient email addresses (1-50 recipients)'),
+          subject: z.string().describe('Email subject line'),
+          text: z.string().describe('Plain text email content'),
+          html: z.string().optional().describe('HTML email content'),
+          from: z
+            .string()
+            .optional()
+            .describe(
+              'Sender email address. Falls back to the configured default sender if not provided.',
+            ),
+          replyTo: z
+            .array(z.string())
+            .optional()
+            .describe(
+              'Reply-to email addresses (e.g. "support@example.com" or "Support Team <support@example.com>")',
+            ),
+          cc: z.array(z.email()).optional().describe('CC email addresses'),
+          bcc: z.array(z.email()).optional().describe('BCC email addresses'),
+          scheduledAt: z
+            .string()
+            .optional()
+            .describe(
+              "Optional schedule time. Uses natural language (e.g., 'tomorrow at 10am') or ISO 8601.",
+            ),
+          tags: z
+            .array(
+              z.object({
+                name: z.string().describe('Tag name (key)'),
+                value: z.string().describe('Tag value'),
+              }),
+            )
+            .optional()
+            .describe('Custom tags for tracking/analytics'),
+          topicId: z
+            .string()
+            .optional()
+            .describe('Topic ID for subscription-based sending'),
+          headers: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe(
+              'Optional custom email headers as key/value pairs (e.g. {"List-Unsubscribe": "<https://example.com/unsubscribe>", "X-Entity-Ref-ID": "unique-id"}).',
+            ),
+        }),
+      )
+      .min(1)
+      .max(100)
+      .describe('Array of email objects to send (1-100 emails)'),
+    idempotencyKey: z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Optional unique key for the whole batch that prevents duplicate batch sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same batch; use a new key for a different batch. Must be 1-256 characters.',
+      ),
+  },
+} as const;
+
+export function addEmailTools(
+  server: McpServer,
+  resend: Resend,
+  {
+    senderEmailAddress,
+    replierEmailAddresses,
+  }: {
+    senderEmailAddress?: string;
+    replierEmailAddresses: string[];
+  },
+) {
+  server.registerTool(
+    'send-email',
+    {
+      ...SEND_EMAIL_TOOL_BASE,
+      inputSchema: getSendEmailInputSchema(
+        senderEmailAddress,
+        replierEmailAddresses,
+      ),
     },
     async ({
       from,
@@ -310,44 +716,7 @@ export function addEmailTools(
 
   server.registerTool(
     'list-emails',
-    {
-      title: 'List Emails',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List recently sent emails (transactional emails sent via send-email) with metadata: recipient, subject, status, timestamps.
-
-**NOT for:** Listing broadcast campaigns (use list-broadcasts). Not for composing or sending.
-
-**Returns:** Paginated list with to, subject, status, created_at, message_id, and ID per email.
-
-**When to use:**
-- User asks "what emails were sent?", "show recent emails", "did my email go out?"
-- Checking delivery status of sent messages
-- Finding an email ID to fetch full content (then use get-email)
-
-**Workflow:** list-emails → get-email( id ) when user needs full body or details.`,
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of emails to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Email ID after which to retrieve more emails (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Email ID before which to retrieve more emails (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_EMAILS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -407,110 +776,68 @@ export function addEmailTools(
     },
   );
 
-  server.registerTool(
-    'get-email',
-    {
-      title: 'Get Email',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve full details of a specific sent transactional email by ID, including message_id, HTML and plain text content.',
-      inputSchema: {
-        id: z.string().describe('The email ID to retrieve'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.emails.get(id);
+  server.registerTool('get-email', GET_EMAIL_TOOL, async ({ id }) => {
+    const response = await resend.emails.get(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to retrieve email: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to retrieve email: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      const email = response.data;
+    const email = response.data;
 
-      if (!email) {
-        throw new Error(`Email with ID ${id} not found.`);
-      }
+    if (!email) {
+      throw new Error(`Email with ID ${id} not found.`);
+    }
 
-      const to = Array.isArray(email.to) ? email.to.join(', ') : email.to;
-      const cc = email.cc
-        ? Array.isArray(email.cc)
-          ? email.cc.join(', ')
-          : email.cc
-        : null;
-      const bcc = email.bcc
-        ? Array.isArray(email.bcc)
-          ? email.bcc.join(', ')
-          : email.bcc
-        : null;
-      const replyTo = email.reply_to
-        ? Array.isArray(email.reply_to)
-          ? email.reply_to.join(', ')
-          : email.reply_to
-        : null;
+    const to = Array.isArray(email.to) ? email.to.join(', ') : email.to;
+    const cc = email.cc
+      ? Array.isArray(email.cc)
+        ? email.cc.join(', ')
+        : email.cc
+      : null;
+    const bcc = email.bcc
+      ? Array.isArray(email.bcc)
+        ? email.bcc.join(', ')
+        : email.bcc
+      : null;
+    const replyTo = email.reply_to
+      ? Array.isArray(email.reply_to)
+        ? email.reply_to.join(', ')
+        : email.reply_to
+      : null;
 
-      let details = `Email Details:\n`;
-      details += `- ID: ${email.id}\n`;
-      details += `- Message ID: ${email.message_id}\n`;
-      details += `- From: ${email.from}\n`;
-      details += `- To: ${to}\n`;
-      if (cc) details += `- CC: ${cc}\n`;
-      if (bcc) details += `- BCC: ${bcc}\n`;
-      if (replyTo) details += `- Reply-To: ${replyTo}\n`;
-      details += `- Subject: ${email.subject}\n`;
-      details += `- Status: ${email.last_event}\n`;
-      details += `- Created: ${email.created_at}\n`;
-      if (email.scheduled_at) details += `- Scheduled: ${email.scheduled_at}\n`;
-      details += `\n--- Plain Text Content ---\n${email.text || '(none)'}\n`;
-      if (email.html) {
-        details += `\n--- HTML Content ---\n${email.html}\n`;
-      }
+    let details = `Email Details:\n`;
+    details += `- ID: ${email.id}\n`;
+    details += `- Message ID: ${email.message_id}\n`;
+    details += `- From: ${email.from}\n`;
+    details += `- To: ${to}\n`;
+    if (cc) details += `- CC: ${cc}\n`;
+    if (bcc) details += `- BCC: ${bcc}\n`;
+    if (replyTo) details += `- Reply-To: ${replyTo}\n`;
+    details += `- Subject: ${email.subject}\n`;
+    details += `- Status: ${email.last_event}\n`;
+    details += `- Created: ${email.created_at}\n`;
+    if (email.scheduled_at) details += `- Scheduled: ${email.scheduled_at}\n`;
+    details += `\n--- Plain Text Content ---\n${email.text || '(none)'}\n`;
+    if (email.html) {
+      details += `\n--- HTML Content ---\n${email.html}\n`;
+    }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: details,
-          },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        {
+          type: 'text',
+          text: details,
+        },
+      ],
+    };
+  });
 
   server.registerTool(
     'list-received-emails',
-    {
-      title: 'List Received Emails',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List emails received (inbox) by your Resend receiving address. Use for "show my inbox", "what emails did I get?", "list incoming mail".
-
-**NOT for:** Listing emails you sent (use list-emails). Not for listing broadcasts (use list-broadcasts).
-
-**Returns:** Paginated metadata: from, to, subject, message_id, received time. Use get-received-email with an ID for full content.`,
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of emails to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Email ID after which to retrieve more emails (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Email ID before which to retrieve more emails (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_RECEIVED_EMAILS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -571,15 +898,7 @@ export function addEmailTools(
 
   server.registerTool(
     'get-received-email',
-    {
-      title: 'Get Received Email',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve full details of a specific received email by ID, including HTML and plain text content, headers, and raw email download URL.',
-      inputSchema: {
-        id: z.string().describe('The received email ID to retrieve'),
-      },
-    },
+    GET_RECEIVED_EMAIL_TOOL,
     async ({ id }) => {
       const response = await resend.emails.receiving.get(id);
 
@@ -646,35 +965,7 @@ export function addEmailTools(
 
   server.registerTool(
     'list-received-email-attachments',
-    {
-      title: 'List Received Email Attachments',
-      annotations: { readOnlyHint: true },
-      description:
-        'List all attachments from a specific received (inbox) email. Returns attachment metadata including filename, size, content type, and a time-limited download URL. Use for emails listed by list-received-emails.',
-      inputSchema: {
-        emailId: z.string().describe('The received email ID'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of attachments to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Attachment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Attachment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_RECEIVED_EMAIL_ATTACHMENTS_TOOL,
     async ({ emailId, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -731,16 +1022,7 @@ export function addEmailTools(
 
   server.registerTool(
     'get-received-email-attachment',
-    {
-      title: 'Get Received Email Attachment',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve details of a specific attachment from a received email, including a time-limited download URL.',
-      inputSchema: {
-        emailId: z.string().describe('The received email ID'),
-        id: z.string().describe('The attachment ID'),
-      },
-    },
+    GET_RECEIVED_EMAIL_ATTACHMENT_TOOL,
     async ({ emailId, id }) => {
       const response = await resend.emails.receiving.attachments.get({
         emailId,
@@ -782,51 +1064,28 @@ export function addEmailTools(
     },
   );
 
-  server.registerTool(
-    'cancel-email',
-    {
-      title: 'Cancel Email',
-      description:
-        'Cancel a scheduled email that has not yet been sent. Only works for emails that were scheduled using the scheduledAt parameter.',
-      inputSchema: {
-        id: z.string().describe('The ID of the scheduled email to cancel'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.emails.cancel(id);
+  server.registerTool('cancel-email', CANCEL_EMAIL_TOOL, async ({ id }) => {
+    const response = await resend.emails.cancel(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to cancel email: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to cancel email: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Email ${response.data?.id} has been cancelled successfully.`,
-          },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Email ${response.data?.id} has been cancelled successfully.`,
+        },
+      ],
+    };
+  });
 
   server.registerTool(
     'update-email',
-    {
-      title: 'Update Email',
-      description:
-        'Reschedule a scheduled email by updating its scheduled send time. Only works for emails that were scheduled and have not yet been sent.',
-      inputSchema: {
-        id: z.string().describe('The ID of the scheduled email to update'),
-        scheduledAt: z
-          .string()
-          .describe(
-            'The new scheduled time in ISO 8601 format (e.g., "2024-08-05T11:52:01.858Z").',
-          ),
-      },
-    },
+    UPDATE_EMAIL_TOOL,
     async ({ id, scheduledAt }) => {
       const response = await resend.emails.update({ id, scheduledAt });
 
@@ -849,22 +1108,7 @@ export function addEmailTools(
 
   server.registerTool(
     'share-email',
-    {
-      title: 'Share Email',
-      description:
-        'Create a shareable link for a sent or received email, so anyone with the link can view it without Resend dashboard access. Works for any email ID, sent or received.',
-      inputSchema: {
-        id: z
-          .string()
-          .describe('The ID of the sent or received email to share'),
-        expiresIn: z
-          .string()
-          .optional()
-          .describe(
-            'How long the share link stays valid, as a human-readable duration (e.g. "10m", "2 hours", "1 day", "1h 30m"). Defaults to 48 hours; capped at 48 hours.',
-          ),
-      },
-    },
+    SHARE_EMAIL_TOOL,
     async ({ id, expiresIn }) => {
       const response = await resend.emails.share(
         id,
@@ -890,96 +1134,7 @@ export function addEmailTools(
 
   server.registerTool(
     'get-email-metrics',
-    {
-      title: 'Email Metrics',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve account-level email delivery and engagement metrics (sent, delivered, bounced, opened, clicked, etc.) for a date range, optionally broken down by period, domain, email, or broadcast.',
-      inputSchema: {
-        startDate: z
-          .string()
-          .optional()
-          .describe(
-            'Start of the date range, as an ISO 8601 date or datetime. Defaults to 6 days before endDate.',
-          ),
-        endDate: z
-          .string()
-          .optional()
-          .describe(
-            'End of the date range, as an ISO 8601 date or datetime. Defaults to now.',
-          ),
-        timezone: z
-          .string()
-          .optional()
-          .describe(
-            'IANA timezone (e.g. "America/New_York") used to bucket periods when "period" is in dimensions. Defaults to UTC.',
-          ),
-        granularity: z
-          .enum(['hourly', 'daily', 'weekly', 'monthly'])
-          .optional()
-          .describe(
-            'Bucket size used when "period" is in dimensions. Defaults to "daily".',
-          ),
-        metrics: z
-          .array(
-            z.enum([
-              'received',
-              'delivered',
-              'complained',
-              'suppressed',
-              'bounced',
-              'bounced_transient',
-              'bounced_permanent',
-              'bounced_undetermined',
-              'opened',
-              'clicked',
-              'unsubscribed',
-              'delivery_delayed',
-              'failed',
-              'sent',
-              'unique_opened',
-              'unique_clicked',
-              'delivery_rate',
-              'open_rate',
-              'click_rate',
-              'bounce_rate',
-              'complaint_rate',
-              'unsubscribe_rate',
-            ]),
-          )
-          .optional()
-          .describe(
-            'Metrics to include in the response. Defaults to all metrics.',
-          ),
-        dimensions: z
-          .array(z.enum(['period', 'domain', 'email', 'broadcast']))
-          .optional()
-          .describe(
-            'Dimensions to break the response down by. "email" and "broadcast" cannot be combined. Defaults to none, which returns totals only.',
-          ),
-        domainId: z
-          .array(z.uuid())
-          .max(100)
-          .optional()
-          .describe(
-            'Restrict the response to these sending domain IDs (max 100).',
-          ),
-        emailId: z
-          .array(z.uuid())
-          .max(100)
-          .optional()
-          .describe(
-            'Restrict the response to these email IDs (max 100). Cannot be combined with the "broadcast" dimension or broadcastId.',
-          ),
-        broadcastId: z
-          .array(z.uuid())
-          .max(100)
-          .optional()
-          .describe(
-            'Restrict the response to these broadcast IDs (max 100). Cannot be combined with the "email" dimension or emailId.',
-          ),
-      },
-    },
+    GET_EMAIL_METRICS_TOOL,
     async ({
       startDate,
       endDate,
@@ -1069,35 +1224,7 @@ export function addEmailTools(
 
   server.registerTool(
     'list-sent-email-attachments',
-    {
-      title: 'List Sent Email Attachments',
-      annotations: { readOnlyHint: true },
-      description:
-        'List all attachments from a specific sent email (from send-email or list-emails). Returns attachment metadata including filename, size, content type, and a time-limited download URL.',
-      inputSchema: {
-        emailId: z.string().describe('The sent email ID'),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of attachments to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Attachment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Attachment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_SENT_EMAIL_ATTACHMENTS_TOOL,
     async ({ emailId, limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -1153,16 +1280,7 @@ export function addEmailTools(
 
   server.registerTool(
     'get-sent-email-attachment',
-    {
-      title: 'Get Sent Email Attachment',
-      annotations: { readOnlyHint: true },
-      description:
-        'Retrieve details of a specific attachment from a sent email, including a time-limited download URL.',
-      inputSchema: {
-        emailId: z.string().describe('The sent email ID'),
-        id: z.string().describe('The attachment ID'),
-      },
-    },
+    GET_SENT_EMAIL_ATTACHMENT_TOOL,
     async ({ emailId, id }) => {
       const response = await resend.emails.attachments.get({
         emailId,
@@ -1206,84 +1324,7 @@ export function addEmailTools(
 
   server.registerTool(
     'send-batch-emails',
-    {
-      title: 'Send Batch Emails',
-      description: `**Purpose:** Send up to 100 transactional emails in one API call. Each item has the same fields as send-email (to, subject, text, from, etc.).
-
-**NOT for:** Sending one email (use send-email) or the same content to a segment (use create-broadcast + send-broadcast).
-
-**When to use:** User wants to send many individual emails in bulk (e.g. 50 password resets, 100 receipts). Not for one-to-many broadcasts.`,
-      inputSchema: {
-        emails: z
-          .array(
-            z.object({
-              to: z
-                .array(z.email())
-                .min(1)
-                .max(50)
-                .describe(
-                  'Array of recipient email addresses (1-50 recipients)',
-                ),
-              subject: z.string().describe('Email subject line'),
-              text: z.string().describe('Plain text email content'),
-              html: z.string().optional().describe('HTML email content'),
-              from: z
-                .string()
-                .optional()
-                .describe(
-                  'Sender email address. Falls back to the configured default sender if not provided.',
-                ),
-              replyTo: z
-                .array(z.string())
-                .optional()
-                .describe(
-                  'Reply-to email addresses (e.g. "support@example.com" or "Support Team <support@example.com>")',
-                ),
-              cc: z.array(z.email()).optional().describe('CC email addresses'),
-              bcc: z
-                .array(z.email())
-                .optional()
-                .describe('BCC email addresses'),
-              scheduledAt: z
-                .string()
-                .optional()
-                .describe(
-                  "Optional schedule time. Uses natural language (e.g., 'tomorrow at 10am') or ISO 8601.",
-                ),
-              tags: z
-                .array(
-                  z.object({
-                    name: z.string().describe('Tag name (key)'),
-                    value: z.string().describe('Tag value'),
-                  }),
-                )
-                .optional()
-                .describe('Custom tags for tracking/analytics'),
-              topicId: z
-                .string()
-                .optional()
-                .describe('Topic ID for subscription-based sending'),
-              headers: z
-                .record(z.string(), z.string())
-                .optional()
-                .describe(
-                  'Optional custom email headers as key/value pairs (e.g. {"List-Unsubscribe": "<https://example.com/unsubscribe>", "X-Entity-Ref-ID": "unique-id"}).',
-                ),
-            }),
-          )
-          .min(1)
-          .max(100)
-          .describe('Array of email objects to send (1-100 emails)'),
-        idempotencyKey: z
-          .string()
-          .min(1)
-          .max(256)
-          .optional()
-          .describe(
-            'Optional unique key for the whole batch that prevents duplicate batch sends on retries (sent as the Idempotency-Key header). Use the same key when retrying the same batch; use a new key for a different batch. Must be 1-256 characters.',
-          ),
-      },
-    },
+    SEND_BATCH_EMAILS_TOOL,
     async ({ emails, idempotencyKey }) => {
       const emailRequests = emails.map((email) => {
         const fromAddress = email.from ?? senderEmailAddress;

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -2,12 +2,14 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-export function addEventTools(server: McpServer, resend: Resend) {
-  server.registerTool(
-    'send-event',
-    {
-      title: 'Send Event',
-      description: `**Purpose:** Fire an event to trigger automations for a specific contact.
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const SEND_EVENT_TOOL = {
+  title: 'Send Event',
+  description: `**Purpose:** Fire an event to trigger automations for a specific contact.
 
 **When to use:**
 - User wants to trigger an automation workflow for a contact
@@ -19,31 +21,90 @@ export function addEventTools(server: McpServer, resend: Resend) {
 - The event name must match the trigger event name in an automation for it to fire.
 - Identify the contact by either contactId OR email, not both.
 - The payload is optional and can contain any key-value data that the automation steps can reference via event.* variables.`,
-      inputSchema: {
-        event: z
-          .string()
-          .nonempty()
-          .describe('The event name (e.g., "user.created", "payment.failed")'),
-        contactId: z
-          .string()
-          .optional()
-          .describe(
-            'The contact ID to associate with the event. Use either contactId or email, not both.',
-          ),
-        email: z
-          .string()
-          .optional()
-          .describe(
-            'The contact email to associate with the event. Use either contactId or email, not both.',
-          ),
-        payload: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe(
-            'Optional key-value data passed to the automation. Accessible in steps via event.* variables.',
-          ),
-      },
-    },
+  inputSchema: {
+    event: z
+      .string()
+      .nonempty()
+      .describe('The event name (e.g., "user.created", "payment.failed")'),
+    contactId: z
+      .string()
+      .optional()
+      .describe(
+        'The contact ID to associate with the event. Use either contactId or email, not both.',
+      ),
+    email: z
+      .string()
+      .optional()
+      .describe(
+        'The contact email to associate with the event. Use either contactId or email, not both.',
+      ),
+    payload: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        'Optional key-value data passed to the automation. Accessible in steps via event.* variables.',
+      ),
+  },
+} as const;
+
+const MANAGE_EVENTS_TOOL = {
+  title: 'Manage Events',
+  description: `**Purpose:** Create, list, get, update, or remove event definitions in Resend.
+
+Events define named triggers that your application sends to start automations. Each event can have an optional schema that validates payload data.
+
+**Actions:**
+- \`create\`: Define a new event with a name and optional schema.
+- \`list\`: List all event definitions (paginated).
+- \`get\`: Get event details by ID or name.
+- \`update\`: Update an event's schema.
+- \`remove\`: Delete an event. You MUST confirm with the user before removing.
+
+**Workflow:** manage-events (create) → create-automation → send-event
+
+**Schema types:** string, number, boolean, date`,
+  inputSchema: {
+    action: z
+      .enum(['create', 'list', 'get', 'update', 'remove'])
+      .describe('The operation to perform.'),
+    name: z
+      .string()
+      .optional()
+      .describe(
+        'Event name (for create). Use dot notation like "user.created". Cannot start with "resend:".',
+      ),
+    identifier: z
+      .string()
+      .optional()
+      .describe('Event ID or name (for get, update, remove).'),
+    schema: z
+      .record(z.string(), z.enum(['string', 'number', 'boolean', 'date']))
+      .nullable()
+      .optional()
+      .describe(
+        'Event payload schema (for create, update). Maps field names to types. Pass null to remove the schema.',
+      ),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of events to retrieve (for list). Default: 20.'),
+    after: z
+      .string()
+      .optional()
+      .describe('Cursor for forward pagination (for list).'),
+    before: z
+      .string()
+      .optional()
+      .describe('Cursor for backward pagination (for list).'),
+  },
+} as const;
+
+export function addEventTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'send-event',
+    SEND_EVENT_TOOL,
     async ({ event, contactId, email, payload }) => {
       if (!contactId && !email) {
         throw new Error(
@@ -92,59 +153,7 @@ export function addEventTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'manage-events',
-    {
-      title: 'Manage Events',
-      description: `**Purpose:** Create, list, get, update, or remove event definitions in Resend.
-
-Events define named triggers that your application sends to start automations. Each event can have an optional schema that validates payload data.
-
-**Actions:**
-- \`create\`: Define a new event with a name and optional schema.
-- \`list\`: List all event definitions (paginated).
-- \`get\`: Get event details by ID or name.
-- \`update\`: Update an event's schema.
-- \`remove\`: Delete an event. You MUST confirm with the user before removing.
-
-**Workflow:** manage-events (create) → create-automation → send-event
-
-**Schema types:** string, number, boolean, date`,
-      inputSchema: {
-        action: z
-          .enum(['create', 'list', 'get', 'update', 'remove'])
-          .describe('The operation to perform.'),
-        name: z
-          .string()
-          .optional()
-          .describe(
-            'Event name (for create). Use dot notation like "user.created". Cannot start with "resend:".',
-          ),
-        identifier: z
-          .string()
-          .optional()
-          .describe('Event ID or name (for get, update, remove).'),
-        schema: z
-          .record(z.string(), z.enum(['string', 'number', 'boolean', 'date']))
-          .nullable()
-          .optional()
-          .describe(
-            'Event payload schema (for create, update). Maps field names to types. Pass null to remove the schema.',
-          ),
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe('Number of events to retrieve (for list). Default: 20.'),
-        after: z
-          .string()
-          .optional()
-          .describe('Cursor for forward pagination (for list).'),
-        before: z
-          .string()
-          .optional()
-          .describe('Cursor for backward pagination (for list).'),
-      },
-    },
+    MANAGE_EVENTS_TOOL,
     async ({ action, name, identifier, schema, limit, after, before }) => {
       switch (action) {
         case 'create': {

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const SEND_EVENT_TOOL = {
   title: 'Send Event',
   description: `**Purpose:** Fire an event to trigger automations for a specific contact.

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -2,13 +2,15 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-export function addLogTools(server: McpServer, resend: Resend) {
-  server.registerTool(
-    'list-logs',
-    {
-      title: 'List Logs',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List API request logs for the account. Use to review recent API activity, debug issues, or audit API usage.
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const LIST_LOGS_TOOL = {
+  title: 'List Logs',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List API request logs for the account. Use to review recent API activity, debug issues, or audit API usage.
 
 **Returns:** For each log: id, created_at, endpoint, method, response_status, user_agent. Use pagination (limit, after/before) for large lists.
 
@@ -16,29 +18,48 @@ export function addLogTools(server: McpServer, resend: Resend) {
 - User wants to see recent API activity
 - Debugging API issues or checking request history
 - User says "show my logs", "what API calls were made?", "check recent requests"`,
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of logs to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Log ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Log ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of logs to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Log ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Log ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_LOG_TOOL = {
+  title: 'Get Log',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** Get detailed information about a specific API request log, including the full request and response bodies.
+
+**Returns:** Log details: id, created_at, endpoint, method, response_status, user_agent, request_body, response_body.
+
+**When to use:**
+- User wants to inspect a specific API request
+- Debugging a particular API call
+- User says "show me that log", "what was in that request?"`,
+  inputSchema: {
+    logId: z.string().nonempty().describe('The Log ID to retrieve'),
+  },
+} as const;
+
+export function addLogTools(server: McpServer, resend: Resend) {
+  server.registerTool(
+    'list-logs',
+    LIST_LOGS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -103,47 +124,29 @@ export function addLogTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'get-log',
-    {
-      title: 'Get Log',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** Get detailed information about a specific API request log, including the full request and response bodies.
+  server.registerTool('get-log', GET_LOG_TOOL, async ({ logId }) => {
+    const response = await resend.logs.get(logId);
 
-**Returns:** Log details: id, created_at, endpoint, method, response_status, user_agent, request_body, response_body.
+    if (response.error) {
+      throw new Error(`Failed to get log: ${JSON.stringify(response.error)}`);
+    }
 
-**When to use:**
-- User wants to inspect a specific API request
-- Debugging a particular API call
-- User says "show me that log", "what was in that request?"`,
-      inputSchema: {
-        logId: z.string().nonempty().describe('The Log ID to retrieve'),
-      },
-    },
-    async ({ logId }) => {
-      const response = await resend.logs.get(logId);
-
-      if (response.error) {
-        throw new Error(`Failed to get log: ${JSON.stringify(response.error)}`);
-      }
-
-      const log = response.data;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `ID: ${log.id}\nEndpoint: ${log.method} ${log.endpoint}\nStatus: ${log.response_status}\nUser Agent: ${log.user_agent}\nCreated at: ${log.created_at}`,
-          },
-          {
-            type: 'text',
-            text: `Request Body:\n${JSON.stringify(log.request_body, null, 2)}`,
-          },
-          {
-            type: 'text',
-            text: `Response Body:\n${JSON.stringify(log.response_body, null, 2)}`,
-          },
-        ],
-      };
-    },
-  );
+    const log = response.data;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `ID: ${log.id}\nEndpoint: ${log.method} ${log.endpoint}\nStatus: ${log.response_status}\nUser Agent: ${log.user_agent}\nCreated at: ${log.created_at}`,
+        },
+        {
+          type: 'text',
+          text: `Request Body:\n${JSON.stringify(log.request_body, null, 2)}`,
+        },
+        {
+          type: 'text',
+          text: `Response Body:\n${JSON.stringify(log.response_body, null, 2)}`,
+        },
+      ],
+    };
+  });
 }

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const LIST_LOGS_TOOL = {
   title: 'List Logs',
   annotations: { readOnlyHint: true },

--- a/src/tools/oauthGrants.ts
+++ b/src/tools/oauthGrants.ts
@@ -2,35 +2,51 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const LIST_OAUTH_GRANTS_TOOL = {
+  title: 'List OAuth Grants',
+  annotations: { readOnlyHint: true },
+  description:
+    "List OAuth grants for the team — the apps authorized to act on the team's behalf. Returns every grant, active and revoked; a grant with a non-null revoked_at is no longer active. Each grant includes the client (app) name, scopes, and creation date. Don't bother telling the user the IDs unless they ask for them.",
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of OAuth grants to retrieve. Max: 100, Min: 1'),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'OAuth grant ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'OAuth grant ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const REVOKE_OAUTH_GRANT_TOOL = {
+  title: 'Revoke OAuth Grant',
+  description:
+    'Revoke an OAuth grant by ID. Before using this tool, you MUST double-check with the user that they want to revoke this grant. Reference the NAME of the app (client) when double-checking, and warn the user that revocation is immediate and irreversible — every access and refresh token issued under the grant stops working, and the app would need to be re-authorized to regain access. You may only use this tool if the user explicitly confirms they want to revoke the grant after you double-check.',
+  inputSchema: {
+    id: z.string().nonempty().describe('OAuth grant ID'),
+  },
+} as const;
+
 export function addOAuthGrantTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'list-oauth-grants',
-    {
-      title: 'List OAuth Grants',
-      annotations: { readOnlyHint: true },
-      description:
-        "List OAuth grants for the team — the apps authorized to act on the team's behalf. Returns every grant, active and revoked; a grant with a non-null revoked_at is no longer active. Each grant includes the client (app) name, scopes, and creation date. Don't bother telling the user the IDs unless they ask for them.",
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe('Number of OAuth grants to retrieve. Max: 100, Min: 1'),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'OAuth grant ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'OAuth grant ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_OAUTH_GRANTS_TOOL,
     async ({ limit, after, before }) => {
       if (after !== undefined && before !== undefined) {
         throw new Error(
@@ -97,14 +113,7 @@ export function addOAuthGrantTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'revoke-oauth-grant',
-    {
-      title: 'Revoke OAuth Grant',
-      description:
-        'Revoke an OAuth grant by ID. Before using this tool, you MUST double-check with the user that they want to revoke this grant. Reference the NAME of the app (client) when double-checking, and warn the user that revocation is immediate and irreversible — every access and refresh token issued under the grant stops working, and the app would need to be re-authorized to regain access. You may only use this tool if the user explicitly confirms they want to revoke the grant after you double-check.',
-      inputSchema: {
-        id: z.string().nonempty().describe('OAuth grant ID'),
-      },
-    },
+    REVOKE_OAUTH_GRANT_TOOL,
     async ({ id }) => {
       const response = await resend.oauthGrants.revoke(id);
 

--- a/src/tools/oauthGrants.ts
+++ b/src/tools/oauthGrants.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const LIST_OAUTH_GRANTS_TOOL = {
   title: 'List OAuth Grants',
   annotations: { readOnlyHint: true },

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_SEGMENT_TOOL = {
   title: 'Create Segment',
   description:

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -2,17 +2,76 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_SEGMENT_TOOL = {
+  title: 'Create Segment',
+  description:
+    'Create a new segment in Resend. A segment is a group of contacts that can be used to target specific broadcasts.',
+  inputSchema: {
+    name: z.string().nonempty().describe('Name for the new segment'),
+  },
+} as const;
+
+const LIST_SEGMENTS_TOOL = {
+  title: 'List Segments',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List all segments in the account. Use to get segment IDs required by create-contact, create-broadcast, list-contacts.
+
+**NOT for:** Listing contacts inside a segment (use list-contacts with segmentId). Not for listing broadcasts (use list-broadcasts).
+
+**Returns:** For each segment: name, id, created_at. Use pagination (limit, after/before) for large lists.
+
+**When to use:** User says "show my segments", "what lists do I have?", or before create-contact/create-broadcast when segmentId is unknown.`,
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of segments to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Segment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Segment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_SEGMENT_TOOL = {
+  title: 'Get Segment',
+  annotations: { readOnlyHint: true },
+  description: 'Get a segment by ID from Resend.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Segment ID'),
+  },
+} as const;
+
+const REMOVE_SEGMENT_TOOL = {
+  title: 'Remove Segment',
+  description:
+    'Remove a segment by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this segment. Reference the NAME of the segment when double-checking, and warn the user that removing a segment is irreversible. You may only use this tool if the user explicitly confirms they want to remove the segment after you double-check.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Segment ID'),
+  },
+} as const;
+
 export function addSegmentTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-segment',
-    {
-      title: 'Create Segment',
-      description:
-        'Create a new segment in Resend. A segment is a group of contacts that can be used to target specific broadcasts.',
-      inputSchema: {
-        name: z.string().nonempty().describe('Name for the new segment'),
-      },
-    },
+    CREATE_SEGMENT_TOOL,
     async ({ name }) => {
       const response = await resend.segments.create({ name });
 
@@ -34,39 +93,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-segments',
-    {
-      title: 'List Segments',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List all segments in the account. Use to get segment IDs required by create-contact, create-broadcast, list-contacts.
-
-**NOT for:** Listing contacts inside a segment (use list-contacts with segmentId). Not for listing broadcasts (use list-broadcasts).
-
-**Returns:** For each segment: name, id, created_at. Use pagination (limit, after/before) for large lists.
-
-**When to use:** User says "show my segments", "what lists do I have?", or before create-contact/create-broadcast when segmentId is unknown.`,
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of segments to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Segment ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Segment ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_SEGMENTS_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -122,62 +149,40 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'get-segment',
-    {
-      title: 'Get Segment',
-      annotations: { readOnlyHint: true },
-      description: 'Get a segment by ID from Resend.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Segment ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.segments.get(id);
+  server.registerTool('get-segment', GET_SEGMENT_TOOL, async ({ id }) => {
+    const response = await resend.segments.get(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to get segment: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to get segment: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      const segment = response.data;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Name: ${segment.name}\nID: ${segment.id}\nCreated at: ${segment.created_at}`,
-          },
-        ],
-      };
-    },
-  );
+    const segment = response.data;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Name: ${segment.name}\nID: ${segment.id}\nCreated at: ${segment.created_at}`,
+        },
+      ],
+    };
+  });
 
-  server.registerTool(
-    'remove-segment',
-    {
-      title: 'Remove Segment',
-      description:
-        'Remove a segment by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this segment. Reference the NAME of the segment when double-checking, and warn the user that removing a segment is irreversible. You may only use this tool if the user explicitly confirms they want to remove the segment after you double-check.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Segment ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.segments.remove(id);
+  server.registerTool('remove-segment', REMOVE_SEGMENT_TOOL, async ({ id }) => {
+    const response = await resend.segments.remove(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to remove segment: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to remove segment: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [
-          { type: 'text', text: 'Segment removed successfully.' },
-          { type: 'text', text: `ID: ${response.data.id}` },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        { type: 'text', text: 'Segment removed successfully.' },
+        { type: 'text', text: `ID: ${response.data.id}` },
+      ],
+    };
+  });
 }

--- a/src/tools/suppressions.ts
+++ b/src/tools/suppressions.ts
@@ -12,11 +12,6 @@ function formatSuppression(suppression: SuppressionListEntry) {
   ].join('\n');
 }
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const ADD_SUPPRESSION_TOOL = {
   title: 'Add Suppression',
   description:

--- a/src/tools/suppressions.ts
+++ b/src/tools/suppressions.ts
@@ -12,17 +12,123 @@ function formatSuppression(suppression: SuppressionListEntry) {
   ].join('\n');
 }
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const ADD_SUPPRESSION_TOOL = {
+  title: 'Add Suppression',
+  description:
+    'Add an email address to the suppression list in Resend. Suppressed addresses never receive emails from the account, even when included as recipients. Hard bounces and spam complaints are added to the suppression list automatically; use this tool to manually suppress an address when needed, e.g. to honor a do-not-contact request. To suppress many addresses at once, use batch-add-suppressions instead.',
+  inputSchema: {
+    email: z.email().describe('Email address to suppress'),
+  },
+} as const;
+
+const LIST_SUPPRESSIONS_TOOL = {
+  title: 'List Suppressions',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List email addresses on the suppression list. Suppressed addresses never receive emails from the account. Optionally filter by origin: "bounce" (added automatically after a hard bounce), "complaint" (added automatically after a spam complaint), or "manual" (added via the API or dashboard).
+
+**NOT for:** Checking a single address (use get-suppression). Not for listing contacts (use list-contacts).
+
+**Returns:** For each suppression: email, id, origin, source_id (when present), created_at. Use pagination (limit, after/before) for large lists.
+
+**When to use:** User says "show my suppression list", "who is suppressed?", or "why isn't this person receiving emails?" combined with a broad look at suppressed addresses.`,
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of suppressions to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Suppression ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Suppression ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+    origin: z
+      .enum(['bounce', 'complaint', 'manual'])
+      .optional()
+      .describe(
+        'Only return suppressions with this origin: "bounce", "complaint", or "manual".',
+      ),
+  },
+} as const;
+
+const GET_SUPPRESSION_TOOL = {
+  title: 'Get Suppression',
+  annotations: { readOnlyHint: true },
+  description:
+    'Get a suppression list entry by ID or email address from Resend. Use this to check whether a specific address is suppressed and why (origin: bounce, complaint, or manual).',
+  inputSchema: {
+    idOrEmail: z
+      .string()
+      .nonempty()
+      .describe('Suppression ID or email address'),
+  },
+} as const;
+
+const REMOVE_SUPPRESSION_TOOL = {
+  title: 'Remove Suppression',
+  description:
+    'Remove an entry by ID or email address from the suppression list in Resend, allowing the address to receive emails again. Before using this tool, you MUST double-check with the user that they want to remove this suppression. Reference the EMAIL ADDRESS when double-checking, and warn the user that the address will start receiving emails again — if it was suppressed due to a bounce or complaint, sending to it may hurt deliverability. You may only use this tool if the user explicitly confirms they want to remove the suppression after you double-check.',
+  inputSchema: {
+    idOrEmail: z
+      .string()
+      .nonempty()
+      .describe('Suppression ID or email address'),
+  },
+} as const;
+
+const BATCH_ADD_SUPPRESSIONS_TOOL = {
+  title: 'Batch Add Suppressions',
+  description:
+    'Add multiple email addresses to the suppression list in Resend in a single call. Suppressed addresses never receive emails from the account. Hard bounces and spam complaints are added to the suppression list automatically; use this tool to manually suppress addresses when needed, e.g. to honor do-not-contact requests. For a single address, use add-suppression instead.',
+  inputSchema: {
+    emails: z
+      .array(z.email())
+      .nonempty()
+      .describe('Email addresses to suppress'),
+  },
+} as const;
+
+const BATCH_REMOVE_SUPPRESSIONS_TOOL = {
+  title: 'Batch Remove Suppressions',
+  description:
+    'Remove multiple entries from the suppression list in Resend in a single call, by email addresses or by suppression IDs (provide exactly one of the two). The addresses will start receiving emails again. Before using this tool, you MUST double-check with the user that they want to remove these suppressions. Reference the EMAIL ADDRESSES (or IDs) when double-checking, and warn the user that addresses suppressed due to a bounce or complaint may hurt deliverability if emailed again. You may only use this tool if the user explicitly confirms they want to remove the suppressions after you double-check.',
+  inputSchema: {
+    emails: z
+      .array(z.email())
+      .nonempty()
+      .optional()
+      .describe(
+        'Email addresses to remove from the suppression list. Cannot be used with "ids".',
+      ),
+    ids: z
+      .array(z.string().nonempty())
+      .nonempty()
+      .optional()
+      .describe(
+        'Suppression IDs to remove from the suppression list. Cannot be used with "emails".',
+      ),
+  },
+} as const;
+
 export function addSuppressionTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'add-suppression',
-    {
-      title: 'Add Suppression',
-      description:
-        'Add an email address to the suppression list in Resend. Suppressed addresses never receive emails from the account, even when included as recipients. Hard bounces and spam complaints are added to the suppression list automatically; use this tool to manually suppress an address when needed, e.g. to honor a do-not-contact request. To suppress many addresses at once, use batch-add-suppressions instead.',
-      inputSchema: {
-        email: z.email().describe('Email address to suppress'),
-      },
-    },
+    ADD_SUPPRESSION_TOOL,
     async ({ email }) => {
       const response = await resend.suppressions.add({ email });
 
@@ -43,45 +149,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-suppressions',
-    {
-      title: 'List Suppressions',
-      annotations: { readOnlyHint: true },
-      description: `**Purpose:** List email addresses on the suppression list. Suppressed addresses never receive emails from the account. Optionally filter by origin: "bounce" (added automatically after a hard bounce), "complaint" (added automatically after a spam complaint), or "manual" (added via the API or dashboard).
-
-**NOT for:** Checking a single address (use get-suppression). Not for listing contacts (use list-contacts).
-
-**Returns:** For each suppression: email, id, origin, source_id (when present), created_at. Use pagination (limit, after/before) for large lists.
-
-**When to use:** User says "show my suppression list", "who is suppressed?", or "why isn't this person receiving emails?" combined with a broad look at suppressed addresses.`,
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of suppressions to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Suppression ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Suppression ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-        origin: z
-          .enum(['bounce', 'complaint', 'manual'])
-          .optional()
-          .describe(
-            'Only return suppressions with this origin: "bounce", "complaint", or "manual".',
-          ),
-      },
-    },
+    LIST_SUPPRESSIONS_TOOL,
     async ({ limit, after, before, origin }) => {
       if (after && before) {
         throw new Error(
@@ -144,18 +212,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-suppression',
-    {
-      title: 'Get Suppression',
-      annotations: { readOnlyHint: true },
-      description:
-        'Get a suppression list entry by ID or email address from Resend. Use this to check whether a specific address is suppressed and why (origin: bounce, complaint, or manual).',
-      inputSchema: {
-        idOrEmail: z
-          .string()
-          .nonempty()
-          .describe('Suppression ID or email address'),
-      },
-    },
+    GET_SUPPRESSION_TOOL,
     async ({ idOrEmail }) => {
       const response = await resend.suppressions.get(idOrEmail);
 
@@ -173,17 +230,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'remove-suppression',
-    {
-      title: 'Remove Suppression',
-      description:
-        'Remove an entry by ID or email address from the suppression list in Resend, allowing the address to receive emails again. Before using this tool, you MUST double-check with the user that they want to remove this suppression. Reference the EMAIL ADDRESS when double-checking, and warn the user that the address will start receiving emails again — if it was suppressed due to a bounce or complaint, sending to it may hurt deliverability. You may only use this tool if the user explicitly confirms they want to remove the suppression after you double-check.',
-      inputSchema: {
-        idOrEmail: z
-          .string()
-          .nonempty()
-          .describe('Suppression ID or email address'),
-      },
-    },
+    REMOVE_SUPPRESSION_TOOL,
     async ({ idOrEmail }) => {
       const response = await resend.suppressions.remove(idOrEmail);
 
@@ -204,17 +251,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'batch-add-suppressions',
-    {
-      title: 'Batch Add Suppressions',
-      description:
-        'Add multiple email addresses to the suppression list in Resend in a single call. Suppressed addresses never receive emails from the account. Hard bounces and spam complaints are added to the suppression list automatically; use this tool to manually suppress addresses when needed, e.g. to honor do-not-contact requests. For a single address, use add-suppression instead.',
-      inputSchema: {
-        emails: z
-          .array(z.email())
-          .nonempty()
-          .describe('Email addresses to suppress'),
-      },
-    },
+    BATCH_ADD_SUPPRESSIONS_TOOL,
     async ({ emails }) => {
       const response = await resend.suppressions.batch.add({ emails });
 
@@ -242,27 +279,7 @@ export function addSuppressionTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'batch-remove-suppressions',
-    {
-      title: 'Batch Remove Suppressions',
-      description:
-        'Remove multiple entries from the suppression list in Resend in a single call, by email addresses or by suppression IDs (provide exactly one of the two). The addresses will start receiving emails again. Before using this tool, you MUST double-check with the user that they want to remove these suppressions. Reference the EMAIL ADDRESSES (or IDs) when double-checking, and warn the user that addresses suppressed due to a bounce or complaint may hurt deliverability if emailed again. You may only use this tool if the user explicitly confirms they want to remove the suppressions after you double-check.',
-      inputSchema: {
-        emails: z
-          .array(z.email())
-          .nonempty()
-          .optional()
-          .describe(
-            'Email addresses to remove from the suppression list. Cannot be used with "ids".',
-          ),
-        ids: z
-          .array(z.string().nonempty())
-          .nonempty()
-          .optional()
-          .describe(
-            'Suppression IDs to remove from the suppression list. Cannot be used with "emails".',
-          ),
-      },
-    },
+    BATCH_REMOVE_SUPPRESSIONS_TOOL,
     async ({ emails, ids }) => {
       if (emails && ids) {
         throw new Error(

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -27,11 +27,6 @@ const templateVariableSchema = z.object({
     ),
 });
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_TEMPLATE_TOOL = {
   title: 'Create Template',
   description: `Create a new email template in Resend. Templates are created in draft status. Use publish-template to make them available for sending. Variables use triple-brace syntax in HTML: {{{VAR_NAME}}}.

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -27,6 +27,236 @@ const templateVariableSchema = z.object({
     ),
 });
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_TEMPLATE_TOOL = {
+  title: 'Create Template',
+  description: `Create a new email template in Resend. Templates are created in draft status. Use publish-template to make them available for sending. Variables use triple-brace syntax in HTML: {{{VAR_NAME}}}.
+
+**Workflow:** create-template → get-tiptap-json-content (with include_schema: true) → compose-template → publish-template.
+
+**Content options after creating:**
+- **compose-template** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the template in the editor.
+- **update-template with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
+  inputSchema: {
+    name: z.string().nonempty().describe('The name of the template.'),
+    html: z
+      .string()
+      .nonempty()
+      .describe(
+        `The HTML content of the template. Use triple-brace syntax for variables: {{{VARIABLE_NAME}}}.\n\n${EMAIL_HTML_RULES}`,
+      ),
+    subject: z
+      .string()
+      .optional()
+      .describe('Default email subject. Can be overridden when sending.'),
+    from: z
+      .string()
+      .optional()
+      .describe(
+        'Sender email address (e.g., "Your Name <sender@example.com>"). Can be overridden when sending.',
+      ),
+    replyTo: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe(
+        'Default Reply-to email address(es). Can be overridden when sending.',
+      ),
+    text: z
+      .string()
+      .optional()
+      .describe(
+        'Plain text version of the message. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
+      ),
+    alias: z
+      .string()
+      .optional()
+      .describe(
+        'An alias for the template. Can be used instead of the ID to reference the template.',
+      ),
+    variables: z
+      .array(templateVariableSchema)
+      .optional()
+      .describe('Array of template variables (up to 50 per template).'),
+  },
+} as const;
+
+const LIST_TEMPLATES_TOOL = {
+  title: 'List Templates',
+  annotations: { readOnlyHint: true },
+  description:
+    "List all email templates from Resend. Returns template names, statuses, and aliases. Don't bother telling the user the IDs unless they ask for them.",
+  inputSchema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of templates to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .optional()
+      .describe(
+        'Template ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
+      ),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        'Template ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
+      ),
+  },
+} as const;
+
+const GET_TEMPLATE_TOOL = {
+  title: 'Get Template',
+  annotations: { readOnlyHint: true },
+  description:
+    'Get an email template by ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>) from Resend. Returns full template details including HTML content, variables, and publish status.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
+      ),
+  },
+} as const;
+
+const COMPOSE_TEMPLATE_TOOL = {
+  title: 'Compose Template',
+  description: `**Purpose:** Set the TipTap JSON content of a template, enabling it to be edited visually in the Resend dashboard editor. Automatically connects and disconnects from the editor. Can also update metadata (subject, name) in the same call.
+
+**This is the recommended way to set email content.** Content set via compose-template can be visually edited by the user in the dashboard.
+
+**Workflow:** get-tiptap-json-content (with include_schema: true) → compose-template
+
+**When to use:**
+- After create-template, to set the email body
+- When the user wants to write, edit, or style email content
+- When the user wants to collaborate on the email in the dashboard editor
+
+**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
+
+**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the template already has HTML content, ask the user before switching to compose mode.`,
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
+      ),
+    content: z
+      .preprocess(
+        (val) => {
+          if (typeof val === 'string') {
+            try {
+              return JSON.parse(val);
+            } catch {
+              return val;
+            }
+          }
+          return val;
+        },
+        z.record(z.string(), z.unknown()),
+      )
+      .describe(
+        'TipTap JSON content. Call get-tiptap-json-content (with include_schema: true) first to get the existing content and the schema reference.',
+      ),
+    subject: z
+      .string()
+      .optional()
+      .describe('Update the default email subject.'),
+    name: z.string().optional().describe('Update the template name.'),
+  },
+} as const;
+
+const UPDATE_TEMPLATE_TOOL = {
+  title: 'Update Template',
+  description: `Update template metadata by ID, alias, or Resend dashboard URL (name, subject, from, html, variables, etc.). After updating a published template, use publish-template again to make the changes live. To edit TipTap content, use compose-template instead.
+
+**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-template. This switch is lossy — some content or formatting may be lost. Prefer compose-template for content changes. If the template was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
+      ),
+    name: z.string().optional().describe('New name for the template.'),
+    html: z
+      .string()
+      .optional()
+      .describe(`New HTML content for the template.\n\n${EMAIL_HTML_RULES}`),
+    subject: z.string().optional().describe('New default email subject.'),
+    from: z.string().optional().describe('New sender email address.'),
+    replyTo: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe('New Reply-to email address(es).'),
+    text: z
+      .string()
+      .optional()
+      .describe(
+        'New plain text version of the message. Pass an empty string to disable automatic text generation.',
+      ),
+    alias: z.string().optional().describe('New alias for the template.'),
+    variables: z
+      .array(templateVariableSchema)
+      .optional()
+      .describe(
+        'New array of template variables (replaces existing variables).',
+      ),
+  },
+} as const;
+
+const REMOVE_TEMPLATE_TOOL = {
+  title: 'Remove Template',
+  description:
+    'Remove an email template by ID, alias, or Resend dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this template. Reference the NAME of the template when double-checking, and warn the user that removing a template is irreversible. You may only use this tool if the user explicitly confirms they want to remove the template after you double-check.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
+      ),
+  },
+} as const;
+
+const PUBLISH_TEMPLATE_TOOL = {
+  title: 'Publish Template',
+  description:
+    'Publish an email template in Resend. Templates must be published before they can be used for sending emails. Re-publishing a previously published template makes the latest changes live. Accepts a template ID, alias, or Resend dashboard URL.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
+      ),
+  },
+} as const;
+
+const DUPLICATE_TEMPLATE_TOOL = {
+  title: 'Duplicate Template',
+  description:
+    'Duplicate an existing email template in Resend. Creates a new draft copy of the template with a new ID. Accepts a template ID, alias, or Resend dashboard URL.',
+  inputSchema: {
+    id: z
+      .string()
+      .nonempty()
+      .describe(
+        'The ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>) of the template to duplicate.',
+      ),
+  },
+} as const;
+
 export function addTemplateTools(
   server: McpServer,
   resend: Resend,
@@ -43,57 +273,7 @@ export function addTemplateTools(
 ) {
   server.registerTool(
     'create-template',
-    {
-      title: 'Create Template',
-      description: `Create a new email template in Resend. Templates are created in draft status. Use publish-template to make them available for sending. Variables use triple-brace syntax in HTML: {{{VAR_NAME}}}.
-
-**Workflow:** create-template → get-tiptap-json-content (with include_schema: true) → compose-template → publish-template.
-
-**Content options after creating:**
-- **compose-template** (recommended): Sets TipTap content that the user can visually edit in the Resend dashboard. Use this when the user wants to collaborate on or refine the template in the editor.
-- **update-template with html/text**: Sets static HTML/text content. Use this only when the user explicitly wants to set raw HTML. Switching between compose and html/text modes is lossy — some content or formatting may be lost. Ask the user before switching.`,
-      inputSchema: {
-        name: z.string().nonempty().describe('The name of the template.'),
-        html: z
-          .string()
-          .nonempty()
-          .describe(
-            `The HTML content of the template. Use triple-brace syntax for variables: {{{VARIABLE_NAME}}}.\n\n${EMAIL_HTML_RULES}`,
-          ),
-        subject: z
-          .string()
-          .optional()
-          .describe('Default email subject. Can be overridden when sending.'),
-        from: z
-          .string()
-          .optional()
-          .describe(
-            'Sender email address (e.g., "Your Name <sender@example.com>"). Can be overridden when sending.',
-          ),
-        replyTo: z
-          .union([z.string(), z.array(z.string())])
-          .optional()
-          .describe(
-            'Default Reply-to email address(es). Can be overridden when sending.',
-          ),
-        text: z
-          .string()
-          .optional()
-          .describe(
-            'Plain text version of the message. If omitted, HTML will be used to generate it. Pass an empty string to disable automatic text generation.',
-          ),
-        alias: z
-          .string()
-          .optional()
-          .describe(
-            'An alias for the template. Can be used instead of the ID to reference the template.',
-          ),
-        variables: z
-          .array(templateVariableSchema)
-          .optional()
-          .describe('Array of template variables (up to 50 per template).'),
-      },
-    },
+    CREATE_TEMPLATE_TOOL,
     async ({ name, html, subject, from, replyTo, text, alias, variables }) => {
       const response = await resend.templates.create({
         name,
@@ -131,34 +311,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'list-templates',
-    {
-      title: 'List Templates',
-      annotations: { readOnlyHint: true },
-      description:
-        "List all email templates from Resend. Returns template names, statuses, and aliases. Don't bother telling the user the IDs unless they ask for them.",
-      inputSchema: {
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            'Number of templates to retrieve. Default: 20, Max: 100, Min: 1',
-          ),
-        after: z
-          .string()
-          .optional()
-          .describe(
-            'Template ID after which to retrieve more (for forward pagination). Cannot be used with "before".',
-          ),
-        before: z
-          .string()
-          .optional()
-          .describe(
-            'Template ID before which to retrieve more (for backward pagination). Cannot be used with "after".',
-          ),
-      },
-    },
+    LIST_TEMPLATES_TOOL,
     async ({ limit, after, before }) => {
       if (after && before) {
         throw new Error(
@@ -216,20 +369,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'get-template',
-    {
-      title: 'Get Template',
-      annotations: { readOnlyHint: true },
-      description:
-        'Get an email template by ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>) from Resend. Returns full template details including HTML content, variables, and publish status.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
-          ),
-      },
-    },
+    GET_TEMPLATE_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'templates');
       const response = await resend.templates.get(id);
@@ -275,53 +415,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'compose-template',
-    {
-      title: 'Compose Template',
-      description: `**Purpose:** Set the TipTap JSON content of a template, enabling it to be edited visually in the Resend dashboard editor. Automatically connects and disconnects from the editor. Can also update metadata (subject, name) in the same call.
-
-**This is the recommended way to set email content.** Content set via compose-template can be visually edited by the user in the dashboard.
-
-**Workflow:** get-tiptap-json-content (with include_schema: true) → compose-template
-
-**When to use:**
-- After create-template, to set the email body
-- When the user wants to write, edit, or style email content
-- When the user wants to collaborate on the email in the dashboard editor
-
-**Important:** Always call get-tiptap-json-content first to retrieve the existing TipTap JSON, then build your changes on top of it. Skipping this will overwrite all existing content.
-
-**Note:** Switching between compose (TipTap) and update (raw HTML) modes is lossy — some content or formatting may be lost. If the template already has HTML content, ask the user before switching to compose mode.`,
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
-          ),
-        content: z
-          .preprocess(
-            (val) => {
-              if (typeof val === 'string') {
-                try {
-                  return JSON.parse(val);
-                } catch {
-                  return val;
-                }
-              }
-              return val;
-            },
-            z.record(z.string(), z.unknown()),
-          )
-          .describe(
-            'TipTap JSON content. Call get-tiptap-json-content (with include_schema: true) first to get the existing content and the schema reference.',
-          ),
-        subject: z
-          .string()
-          .optional()
-          .describe('Update the default email subject.'),
-        name: z.string().optional().describe('Update the template name.'),
-      },
-    },
+    COMPOSE_TEMPLATE_TOOL,
     async ({ id: rawId, content, subject, name }, ctx) => {
       const id = extractIdFromUrl(rawId, 'templates');
       // Compose the TipTap content with editor session
@@ -439,46 +533,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'update-template',
-    {
-      title: 'Update Template',
-      description: `Update template metadata by ID, alias, or Resend dashboard URL (name, subject, from, html, variables, etc.). After updating a published template, use publish-template again to make the changes live. To edit TipTap content, use compose-template instead.
-
-**Note on html/text fields:** Setting html or text via this tool replaces any content previously set via compose-template. This switch is lossy — some content or formatting may be lost. Prefer compose-template for content changes. If the template was composed with TipTap content, ask the user before overwriting it with raw HTML.`,
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
-          ),
-        name: z.string().optional().describe('New name for the template.'),
-        html: z
-          .string()
-          .optional()
-          .describe(
-            `New HTML content for the template.\n\n${EMAIL_HTML_RULES}`,
-          ),
-        subject: z.string().optional().describe('New default email subject.'),
-        from: z.string().optional().describe('New sender email address.'),
-        replyTo: z
-          .union([z.string(), z.array(z.string())])
-          .optional()
-          .describe('New Reply-to email address(es).'),
-        text: z
-          .string()
-          .optional()
-          .describe(
-            'New plain text version of the message. Pass an empty string to disable automatic text generation.',
-          ),
-        alias: z.string().optional().describe('New alias for the template.'),
-        variables: z
-          .array(templateVariableSchema)
-          .optional()
-          .describe(
-            'New array of template variables (replaces existing variables).',
-          ),
-      },
-    },
+    UPDATE_TEMPLATE_TOOL,
     async ({
       id: rawId,
       name,
@@ -527,19 +582,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'remove-template',
-    {
-      title: 'Remove Template',
-      description:
-        'Remove an email template by ID, alias, or Resend dashboard URL from Resend. Before using this tool, you MUST double-check with the user that they want to remove this template. Reference the NAME of the template when double-checking, and warn the user that removing a template is irreversible. You may only use this tool if the user explicitly confirms they want to remove the template after you double-check.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
-          ),
-      },
-    },
+    REMOVE_TEMPLATE_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'templates');
       const response = await resend.templates.remove(id);
@@ -561,19 +604,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'publish-template',
-    {
-      title: 'Publish Template',
-      description:
-        'Publish an email template in Resend. Templates must be published before they can be used for sending emails. Re-publishing a previously published template makes the latest changes live. Accepts a template ID, alias, or Resend dashboard URL.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The template ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>)',
-          ),
-      },
-    },
+    PUBLISH_TEMPLATE_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'templates');
       const response = await resend.templates.publish(id);
@@ -595,19 +626,7 @@ export function addTemplateTools(
 
   server.registerTool(
     'duplicate-template',
-    {
-      title: 'Duplicate Template',
-      description:
-        'Duplicate an existing email template in Resend. Creates a new draft copy of the template with a new ID. Accepts a template ID, alias, or Resend dashboard URL.',
-      inputSchema: {
-        id: z
-          .string()
-          .nonempty()
-          .describe(
-            'The ID, alias, or Resend dashboard URL (e.g. https://resend.com/templates/<id>) of the template to duplicate.',
-          ),
-      },
-    },
+    DUPLICATE_TEMPLATE_TOOL,
     async ({ id: rawId }) => {
       const id = extractIdFromUrl(rawId, 'templates');
       const response = await resend.templates.duplicate(id);

--- a/src/tools/topics.ts
+++ b/src/tools/topics.ts
@@ -2,11 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_TOPIC_TOOL = {
   title: 'Create Topic',
   description:

--- a/src/tools/topics.ts
+++ b/src/tools/topics.ts
@@ -2,31 +2,84 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import type { Resend } from 'resend';
 import { z } from 'zod';
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_TOPIC_TOOL = {
+  title: 'Create Topic',
+  description:
+    'Create a new topic in Resend. Topics allow contacts to manage their subscription preferences for different types of emails.',
+  inputSchema: {
+    name: z
+      .string()
+      .nonempty()
+      .max(50)
+      .describe('Topic name (max 50 characters)'),
+    defaultSubscription: z
+      .enum(['opt_in', 'opt_out'])
+      .describe(
+        'Default subscription preference for new contacts. Cannot be modified after creation.',
+      ),
+    description: z
+      .string()
+      .max(200)
+      .optional()
+      .describe('Topic description (max 200 characters)'),
+  },
+} as const;
+
+const LIST_TOPICS_TOOL = {
+  title: 'List Topics',
+  annotations: { readOnlyHint: true },
+  description:
+    'List all topics from Resend. This tool is useful for getting topic IDs to use with other tools like send-email.',
+  inputSchema: {},
+} as const;
+
+const GET_TOPIC_TOOL = {
+  title: 'Get Topic',
+  annotations: { readOnlyHint: true },
+  description: 'Get a topic by ID from Resend.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Topic ID'),
+  },
+} as const;
+
+const UPDATE_TOPIC_TOOL = {
+  title: 'Update Topic',
+  description:
+    'Update an existing topic in Resend. Note: defaultSubscription cannot be modified after creation.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Topic ID'),
+    name: z
+      .string()
+      .nonempty()
+      .max(50)
+      .optional()
+      .describe('New topic name (max 50 characters)'),
+    description: z
+      .string()
+      .max(200)
+      .optional()
+      .describe('New topic description (max 200 characters)'),
+  },
+} as const;
+
+const REMOVE_TOPIC_TOOL = {
+  title: 'Remove Topic',
+  description:
+    'Remove a topic by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this topic. Reference the NAME of the topic when double-checking, and warn the user that removing a topic is irreversible. You may only use this tool if the user explicitly confirms they want to remove the topic after you double-check.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Topic ID'),
+  },
+} as const;
+
 export function addTopicTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-topic',
-    {
-      title: 'Create Topic',
-      description:
-        'Create a new topic in Resend. Topics allow contacts to manage their subscription preferences for different types of emails.',
-      inputSchema: {
-        name: z
-          .string()
-          .nonempty()
-          .max(50)
-          .describe('Topic name (max 50 characters)'),
-        defaultSubscription: z
-          .enum(['opt_in', 'opt_out'])
-          .describe(
-            'Default subscription preference for new contacts. Cannot be modified after creation.',
-          ),
-        description: z
-          .string()
-          .max(200)
-          .optional()
-          .describe('Topic description (max 200 characters)'),
-      },
-    },
+    CREATE_TOPIC_TOOL,
     async ({ name, defaultSubscription, description }) => {
       const response = await resend.topics.create({
         name,
@@ -50,104 +103,63 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'list-topics',
-    {
-      title: 'List Topics',
-      annotations: { readOnlyHint: true },
-      description:
-        'List all topics from Resend. This tool is useful for getting topic IDs to use with other tools like send-email.',
-      inputSchema: {},
-    },
-    async (_args, _ctx) => {
-      const response = await resend.topics.list();
+  server.registerTool('list-topics', LIST_TOPICS_TOOL, async (_args, _ctx) => {
+    const response = await resend.topics.list();
 
-      if (response.error) {
-        throw new Error(
-          `Failed to list topics: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to list topics: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      const topics = response.data.data;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Found ${topics.length} topic${topics.length === 1 ? '' : 's'}${topics.length === 0 ? '.' : ':'}`,
-          },
-          ...topics.map((topic) => {
-            const t = topic as unknown as {
-              visibility?: string;
-            };
-            const defaultSub = topic.default_subscription;
-            const visibility = t.visibility;
-            return {
-              type: 'text' as const,
-              text: `Name: ${topic.name}\nID: ${topic.id}\nDescription: ${topic.description || '(none)'}\nDefault subscription: ${defaultSub}\nVisibility: ${visibility ?? '(unknown)'}`,
-            };
-          }),
-        ],
-      };
-    },
-  );
+    const topics = response.data.data;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Found ${topics.length} topic${topics.length === 1 ? '' : 's'}${topics.length === 0 ? '.' : ':'}`,
+        },
+        ...topics.map((topic) => {
+          const t = topic as unknown as {
+            visibility?: string;
+          };
+          const defaultSub = topic.default_subscription;
+          const visibility = t.visibility;
+          return {
+            type: 'text' as const,
+            text: `Name: ${topic.name}\nID: ${topic.id}\nDescription: ${topic.description || '(none)'}\nDefault subscription: ${defaultSub}\nVisibility: ${visibility ?? '(unknown)'}`,
+          };
+        }),
+      ],
+    };
+  });
 
-  server.registerTool(
-    'get-topic',
-    {
-      title: 'Get Topic',
-      annotations: { readOnlyHint: true },
-      description: 'Get a topic by ID from Resend.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.topics.get(id);
+  server.registerTool('get-topic', GET_TOPIC_TOOL, async ({ id }) => {
+    const response = await resend.topics.get(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to get topic: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(`Failed to get topic: ${JSON.stringify(response.error)}`);
+    }
 
-      const topic = response.data;
-      const t = topic as unknown as {
-        visibility?: string;
-      };
-      const defaultSub = topic.default_subscription;
-      const visibility = t.visibility;
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Name: ${topic.name}\nID: ${topic.id}\nDescription: ${topic.description || '(none)'}\nDefault subscription: ${defaultSub}\nVisibility: ${visibility ?? '(unknown)'}\nCreated at: ${topic.created_at}`,
-          },
-        ],
-      };
-    },
-  );
+    const topic = response.data;
+    const t = topic as unknown as {
+      visibility?: string;
+    };
+    const defaultSub = topic.default_subscription;
+    const visibility = t.visibility;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Name: ${topic.name}\nID: ${topic.id}\nDescription: ${topic.description || '(none)'}\nDefault subscription: ${defaultSub}\nVisibility: ${visibility ?? '(unknown)'}\nCreated at: ${topic.created_at}`,
+        },
+      ],
+    };
+  });
 
   server.registerTool(
     'update-topic',
-    {
-      title: 'Update Topic',
-      description:
-        'Update an existing topic in Resend. Note: defaultSubscription cannot be modified after creation.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
-        name: z
-          .string()
-          .nonempty()
-          .max(50)
-          .optional()
-          .describe('New topic name (max 50 characters)'),
-        description: z
-          .string()
-          .max(200)
-          .optional()
-          .describe('New topic description (max 200 characters)'),
-      },
-    },
+    UPDATE_TOPIC_TOOL,
     async ({ id, name, description }) => {
       const response = await resend.topics.update({
         id,
@@ -170,31 +182,20 @@ export function addTopicTools(server: McpServer, resend: Resend) {
     },
   );
 
-  server.registerTool(
-    'remove-topic',
-    {
-      title: 'Remove Topic',
-      description:
-        'Remove a topic by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this topic. Reference the NAME of the topic when double-checking, and warn the user that removing a topic is irreversible. You may only use this tool if the user explicitly confirms they want to remove the topic after you double-check.',
-      inputSchema: {
-        id: z.string().nonempty().describe('Topic ID'),
-      },
-    },
-    async ({ id }) => {
-      const response = await resend.topics.remove(id);
+  server.registerTool('remove-topic', REMOVE_TOPIC_TOOL, async ({ id }) => {
+    const response = await resend.topics.remove(id);
 
-      if (response.error) {
-        throw new Error(
-          `Failed to remove topic: ${JSON.stringify(response.error)}`,
-        );
-      }
+    if (response.error) {
+      throw new Error(
+        `Failed to remove topic: ${JSON.stringify(response.error)}`,
+      );
+    }
 
-      return {
-        content: [
-          { type: 'text', text: 'Topic removed successfully.' },
-          { type: 'text', text: `ID: ${response.data.id}` },
-        ],
-      };
-    },
-  );
+    return {
+      content: [
+        { type: 'text', text: 'Topic removed successfully.' },
+        { type: 'text', text: `ID: ${response.data.id}` },
+      ],
+    };
+  });
 }

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -22,21 +22,76 @@ const webhookEventSchema = z.enum([
   'domain.deleted',
 ]);
 
+// Tool schemas/metadata are built once at module load, not per request:
+// createMcpServer() runs on every HTTP request, and rebuilding these Zod
+// schema trees each time is expensive enough to matter under concurrent
+// long-lived connections (e.g. subscriptions/listen streams held open for
+// minutes to hours each retain their own copy for the connection's lifetime).
+const CREATE_WEBHOOK_TOOL = {
+  title: 'Create Webhook',
+  description:
+    'Create a new webhook in Resend. A webhook allows you to receive notifications at a specified URL when certain events occur (e.g. email.sent, email.delivered, email.bounced).',
+  inputSchema: {
+    endpoint: z.url().describe('The URL where webhook events will be sent'),
+    events: webhookEventSchema
+      .array()
+      .min(1)
+      .describe('Array of event types to subscribe to'),
+  },
+} as const;
+
+const LIST_WEBHOOKS_TOOL = {
+  title: 'List Webhooks',
+  annotations: { readOnlyHint: true },
+  description:
+    'List all webhooks from Resend. Use to get webhook IDs and see which endpoints and events are configured. Not for listing emails, segments, or broadcasts.',
+  inputSchema: {},
+} as const;
+
+const GET_WEBHOOK_TOOL = {
+  title: 'Get Webhook',
+  annotations: { readOnlyHint: true },
+  description: 'Get a webhook by ID from Resend.',
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+  },
+} as const;
+
+const UPDATE_WEBHOOK_TOOL = {
+  title: 'Update Webhook',
+  description:
+    'Update an existing webhook in Resend. You can change the endpoint URL, subscribed events, or enable/disable the webhook.',
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+    endpoint: z
+      .url()
+      .optional()
+      .describe('New URL where webhook events will be sent'),
+    events: webhookEventSchema
+      .array()
+      .min(1)
+      .optional()
+      .describe('New array of event types to subscribe to'),
+    status: z
+      .enum(['enabled', 'disabled'])
+      .optional()
+      .describe('Webhook status'),
+  },
+} as const;
+
+const REMOVE_WEBHOOK_TOOL = {
+  title: 'Remove Webhook',
+  description:
+    'Remove a webhook by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this webhook. Reference the ENDPOINT of the webhook when double-checking, and warn the user that removing a webhook is irreversible. You may only use this tool if the user explicitly confirms they want to remove the webhook after you double-check.',
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+  },
+} as const;
+
 export function addWebhookTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-webhook',
-    {
-      title: 'Create Webhook',
-      description:
-        'Create a new webhook in Resend. A webhook allows you to receive notifications at a specified URL when certain events occur (e.g. email.sent, email.delivered, email.bounced).',
-      inputSchema: {
-        endpoint: z.url().describe('The URL where webhook events will be sent'),
-        events: webhookEventSchema
-          .array()
-          .min(1)
-          .describe('Array of event types to subscribe to'),
-      },
-    },
+    CREATE_WEBHOOK_TOOL,
     async ({ endpoint, events }) => {
       const response = await resend.webhooks.create({ endpoint, events });
 
@@ -65,13 +120,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'list-webhooks',
-    {
-      title: 'List Webhooks',
-      annotations: { readOnlyHint: true },
-      description:
-        'List all webhooks from Resend. Use to get webhook IDs and see which endpoints and events are configured. Not for listing emails, segments, or broadcasts.',
-      inputSchema: {},
-    },
+    LIST_WEBHOOKS_TOOL,
     async (_args, _ctx) => {
       const response = await resend.webhooks.list();
 
@@ -99,14 +148,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'get-webhook',
-    {
-      title: 'Get Webhook',
-      annotations: { readOnlyHint: true },
-      description: 'Get a webhook by ID from Resend.',
-      inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
-      },
-    },
+    GET_WEBHOOK_TOOL,
     async ({ webhookId }) => {
       const response = await resend.webhooks.get(webhookId);
 
@@ -130,27 +172,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'update-webhook',
-    {
-      title: 'Update Webhook',
-      description:
-        'Update an existing webhook in Resend. You can change the endpoint URL, subscribed events, or enable/disable the webhook.',
-      inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
-        endpoint: z
-          .url()
-          .optional()
-          .describe('New URL where webhook events will be sent'),
-        events: webhookEventSchema
-          .array()
-          .min(1)
-          .optional()
-          .describe('New array of event types to subscribe to'),
-        status: z
-          .enum(['enabled', 'disabled'])
-          .optional()
-          .describe('Webhook status'),
-      },
-    },
+    UPDATE_WEBHOOK_TOOL,
     async ({ webhookId, endpoint, events, status }) => {
       const response = await resend.webhooks.update(webhookId, {
         endpoint,
@@ -175,14 +197,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
 
   server.registerTool(
     'remove-webhook',
-    {
-      title: 'Remove Webhook',
-      description:
-        'Remove a webhook by ID from Resend. Before using this tool, you MUST double-check with the user that they want to remove this webhook. Reference the ENDPOINT of the webhook when double-checking, and warn the user that removing a webhook is irreversible. You may only use this tool if the user explicitly confirms they want to remove the webhook after you double-check.',
-      inputSchema: {
-        webhookId: z.string().nonempty().describe('Webhook ID'),
-      },
-    },
+    REMOVE_WEBHOOK_TOOL,
     async ({ webhookId }) => {
       const response = await resend.webhooks.remove(webhookId);
 

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -22,11 +22,6 @@ const webhookEventSchema = z.enum([
   'domain.deleted',
 ]);
 
-// Tool schemas/metadata are built once at module load, not per request:
-// createMcpServer() runs on every HTTP request, and rebuilding these Zod
-// schema trees each time is expensive enough to matter under concurrent
-// long-lived connections (e.g. subscriptions/listen streams held open for
-// minutes to hours each retain their own copy for the connection's lifetime).
 const CREATE_WEBHOOK_TOOL = {
   title: 'Create Webhook',
   description:


### PR DESCRIPTION
Same fix applied to remote mcp.`createMcpServer()` runs per request/session and was rebuilding every tool's Zod schema tree from scratch each time. Hoists each tool's static config to a module-level constant; `send-email`/`create-broadcast` use a small memoized builder since their schema depends on `senderEmailAddress`/`replierEmailAddresses`.

**Verification:** measured heap growth (`--expose-gc`, forced GC, `process.memoryUsage().heapUsed`) creating N concurrent server instances via `createMcpServer()`, before vs after, on this repo:

| Connections | Before | After |
|---|---|---|
| 200 | ~7.0 MB/connection | ~0.71 MB/connection |
| 2000 | — | ~0.70 MB/connection (flat, confirms no blowup at scale) |

~10x lower per-connection memory cost; idle baseline unchanged.

- `npx tsc --noEmit` — clean
- `npx biome check` — clean
- `npm test` — 212/212 passing