### PR TITLE
feat(segments): add update-segment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Automations**: Create, list, get, update, duplicate, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.
-- **Segments**: Create, list, get, and remove audience segments.
+- **Segments**: Create, list, get, update, and remove audience segments.
 - **Suppressions**: List, get, add, and remove suppression list entries, individually or in batch. Hard bounces and spam complaints are suppressed automatically; add addresses manually to honor do-not-contact requests.
 - **Topics**: Create, list, get, update, and remove subscription topics.
 - **Contact Properties**: Create, list, get, update, and remove custom contact attributes.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.22.0",
+    "resend": "6.23.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.22.0:
-    resolution: {integrity: sha512-dP1jyl0n1Dx7GYDb0bcsbv9Yx0oBRLhUtSyNFRIOsSzV9MvCVbua/3WP6YUP2JptAU5BciEWGInV+hFjUuYLUw==}
+  resend@6.23.0:
+    resolution: {integrity: sha512-Yzdq6egQDmhkHzkYOiD0e0zj2m8TUxAPH6vzhF+KQWUhcK1BYgoUjr1dcazLu41+I4A2YLDEY3b0Df25wCVwiA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.22.0:
+  resend@6.23.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -177,10 +177,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
     'update-segment',
     UPDATE_SEGMENT_TOOL,
     async ({ id, name }) => {
-      const response = await resend.patch<{
-        object: 'segment';
-        id: string;
-      }>(`/segments/${id}`, { name });
+      const response = await resend.segments.update(id, { name });
 
       if (response.error) {
         throw new Error(

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -54,6 +54,15 @@ const GET_SEGMENT_TOOL = {
   },
 } as const;
 
+const UPDATE_SEGMENT_TOOL = {
+  title: 'Update Segment',
+  description: 'Rename an existing segment in Resend.',
+  inputSchema: {
+    id: z.string().nonempty().describe('Segment ID'),
+    name: z.string().nonempty().describe('New name for the segment'),
+  },
+} as const;
+
 const REMOVE_SEGMENT_TOOL = {
   title: 'Remove Segment',
   description:
@@ -163,6 +172,32 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
       ],
     };
   });
+
+  server.registerTool(
+    'update-segment',
+    UPDATE_SEGMENT_TOOL,
+    async ({ id, name }) => {
+      const response = await resend.patch<{
+        object: 'segment';
+        id: string;
+        name: string;
+      }>(`/segments/${id}`, { name });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to update segment: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const updated = response.data;
+      return {
+        content: [
+          { type: 'text', text: 'Segment updated successfully.' },
+          { type: 'text', text: `Name: ${updated.name}\nID: ${updated.id}` },
+        ],
+      };
+    },
+  );
 
   server.registerTool('remove-segment', REMOVE_SEGMENT_TOOL, async ({ id }) => {
     const response = await resend.segments.remove(id);

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -180,7 +180,6 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
       const response = await resend.patch<{
         object: 'segment';
         id: string;
-        name: string;
       }>(`/segments/${id}`, { name });
 
       if (response.error) {
@@ -193,7 +192,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
       return {
         content: [
           { type: 'text', text: 'Segment updated successfully.' },
-          { type: 'text', text: `Name: ${updated.name}\nID: ${updated.id}` },
+          { type: 'text', text: `Name: ${name}\nID: ${updated.id}` },
         ],
       };
     },

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -189,7 +189,7 @@ export function addSegmentTools(server: McpServer, resend: Resend) {
       return {
         content: [
           { type: 'text', text: 'Segment updated successfully.' },
-          { type: 'text', text: `Name: ${name}\nID: ${updated.id}` },
+          { type: 'text', text: `ID: ${updated.id}` },
         ],
       };
     },

--- a/tests/tools/segments.test.ts
+++ b/tests/tools/segments.test.ts
@@ -62,7 +62,7 @@ describe('update-segment', () => {
 
   it('renames a segment and returns the updated name and ID', async () => {
     patch.mockResolvedValue({
-      data: { object: 'segment', id: 'seg_1', name: 'New name' },
+      data: { object: 'segment', id: 'seg_1' },
       error: null,
     });
 

--- a/tests/tools/segments.test.ts
+++ b/tests/tools/segments.test.ts
@@ -1,0 +1,110 @@
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addSegmentTools } from '../../src/tools/segments.js';
+
+const create = vi.fn();
+const list = vi.fn();
+const get = vi.fn();
+const remove = vi.fn();
+const patch = vi.fn();
+
+const resend = {
+  segments: { create, list, get, remove },
+  patch,
+} as unknown as Resend;
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addSegmentTools(server, resend);
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+describe('segment tools', () => {
+  it('registers the five segment tools', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('create-segment');
+    expect(names).toContain('list-segments');
+    expect(names).toContain('get-segment');
+    expect(names).toContain('update-segment');
+    expect(names).toContain('remove-segment');
+  });
+
+  it('requires user confirmation in the removal tool description', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === 'remove-segment');
+    expect(tool?.description).toContain('double-check with the user');
+  });
+});
+
+describe('update-segment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renames a segment and returns the updated name and ID', async () => {
+    patch.mockResolvedValue({
+      data: { object: 'segment', id: 'seg_1', name: 'New name' },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'update-segment',
+      arguments: { id: 'seg_1', name: 'New name' },
+    });
+
+    expect(patch).toHaveBeenCalledWith('/segments/seg_1', {
+      name: 'New name',
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('Segment updated successfully.');
+    expect(text).toContain('Name: New name');
+    expect(text).toContain('ID: seg_1');
+  });
+
+  it('rejects a missing name', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'update-segment',
+      arguments: { id: 'seg_1', name: '' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces API errors', async () => {
+    patch.mockResolvedValueOnce({
+      error: { message: 'segment not found' },
+      data: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'update-segment',
+      arguments: { id: 'seg_1', name: 'New name' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Failed to update segment');
+  });
+});

--- a/tests/tools/segments.test.ts
+++ b/tests/tools/segments.test.ts
@@ -7,12 +7,11 @@ import { addSegmentTools } from '../../src/tools/segments.js';
 const create = vi.fn();
 const list = vi.fn();
 const get = vi.fn();
+const update = vi.fn();
 const remove = vi.fn();
-const patch = vi.fn();
 
 const resend = {
-  segments: { create, list, get, remove },
-  patch,
+  segments: { create, list, get, update, remove },
 } as unknown as Resend;
 
 async function makeClient() {
@@ -61,7 +60,7 @@ describe('update-segment', () => {
   });
 
   it('renames a segment and returns the updated name and ID', async () => {
-    patch.mockResolvedValue({
+    update.mockResolvedValue({
       data: { object: 'segment', id: 'seg_1' },
       error: null,
     });
@@ -72,9 +71,7 @@ describe('update-segment', () => {
       arguments: { id: 'seg_1', name: 'New name' },
     });
 
-    expect(patch).toHaveBeenCalledWith('/segments/seg_1', {
-      name: 'New name',
-    });
+    expect(update).toHaveBeenCalledWith('seg_1', { name: 'New name' });
     const text = textOf(result as never);
     expect(text).toContain('Segment updated successfully.');
     expect(text).toContain('Name: New name');
@@ -89,11 +86,11 @@ describe('update-segment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(patch).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('surfaces API errors', async () => {
-    patch.mockResolvedValueOnce({
+    update.mockResolvedValueOnce({
       error: { message: 'segment not found' },
       data: null,
     });

--- a/tests/tools/segments.test.ts
+++ b/tests/tools/segments.test.ts
@@ -59,7 +59,7 @@ describe('update-segment', () => {
     vi.clearAllMocks();
   });
 
-  it('renames a segment and returns the updated name and ID', async () => {
+  it('renames a segment and returns the ID', async () => {
     update.mockResolvedValue({
       data: { object: 'segment', id: 'seg_1' },
       error: null,
@@ -74,7 +74,6 @@ describe('update-segment', () => {
     expect(update).toHaveBeenCalledWith('seg_1', { name: 'New name' });
     const text = textOf(result as never);
     expect(text).toContain('Segment updated successfully.');
-    expect(text).toContain('Name: New name');
     expect(text).toContain('ID: seg_1');
   });
 


### PR DESCRIPTION
Adds an `update-segment` MCP tool for `PATCH /segments/:id`, which renames a segment.

**Input schema:** `{ id: string, name: string }` (both required).

**Response:** `{ object: "segment", id: string }`.

The Node SDK (`resend` v6.22.1, currently latest) doesn't yet expose `resend.segments.update(...)` for this endpoint, so the tool calls the client's generic `resend.patch('/segments/{id}', { name })` instead, mirroring how the SDK itself falls back to generic HTTP verbs for endpoints not yet wrapped by a resource-specific method. Once the SDK ships `segments.update`, this can be swapped over to match `update-topic`'s pattern.

Rollout: https://linear.app/resend/issue/DEV-1941/api-change-rollout-rename-segments-through-the-api