### PR TITLE
feat(webhooks): add event inspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Topics**: Create, list, get, update, and remove subscription topics.
 - **Contact Properties**: Create, list, get, update, and remove custom contact attributes.
 - **API Keys**: Create, list, update, and remove API keys.
-- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications.
+- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications, and inspect their delivery history — the events sent to a webhook, one event's payload, and the attempts made to deliver it.
 - **Logs**: List and inspect API request logs, including full request and response bodies.
 - **Editor**: Connect to (and disconnect from) the visual editor in the Resend dashboard, and read a draft's content while collaborating on broadcasts and templates.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.23.0",
+    "resend": "6.25.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.23.0
-        version: 6.23.0
+        specifier: 6.25.0
+        version: 6.25.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.23.0:
-    resolution: {integrity: sha512-Yzdq6egQDmhkHzkYOiD0e0zj2m8TUxAPH6vzhF+KQWUhcK1BYgoUjr1dcazLu41+I4A2YLDEY3b0Df25wCVwiA==}
+  resend@6.25.0:
+    resolution: {integrity: sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.23.0:
+  resend@6.25.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -20,6 +20,8 @@ const webhookEventSchema = z.enum([
   'domain.created',
   'domain.updated',
   'domain.deleted',
+  'suppression.added',
+  'suppression.removed',
 ]);
 
 const CREATE_WEBHOOK_TOOL = {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -282,9 +282,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
       const events = response.data.data;
       if (events.length === 0) {
         return {
-          content: [
-            { type: 'text', text: 'No events delivered to this webhook yet.' },
-          ],
+          content: [{ type: 'text', text: 'No webhook events found.' }],
         };
       }
 
@@ -292,12 +290,20 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
         content: [
           {
             type: 'text',
-            text: `Found ${events.length} event${events.length === 1 ? '' : 's'}${response.data.has_more ? ' (more available, paginate with "after")' : ''}:`,
+            text: `Found ${events.length} webhook event${events.length === 1 ? '' : 's'}:`,
           },
           ...events.map(({ id, type, status, created_at }) => ({
             type: 'text' as const,
             text: `Type: ${type}\nStatus: ${status}\nID: ${id}\nCreated at: ${created_at}`,
           })),
+          ...(response.data.has_more
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more webhook events available. Use the "after" parameter with the last ID to retrieve more.',
+                },
+              ]
+            : []),
         ],
       };
     },
@@ -354,9 +360,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
       const attempts = response.data.data;
       if (attempts.length === 0) {
         return {
-          content: [
-            { type: 'text', text: 'No delivery attempts for this event yet.' },
-          ],
+          content: [{ type: 'text', text: 'No delivery attempts found.' }],
         };
       }
 
@@ -364,7 +368,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
         content: [
           {
             type: 'text',
-            text: `Found ${attempts.length} attempt${attempts.length === 1 ? '' : 's'}${response.data.has_more ? ' (more available, paginate with "after")' : ''}:`,
+            text: `Found ${attempts.length} delivery attempt${attempts.length === 1 ? '' : 's'}:`,
           },
           ...attempts.map(
             ({ id, http_status_code, response: body, sent_at }) => ({
@@ -372,6 +376,14 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
               text: `HTTP status: ${http_status_code}\nSent at: ${sent_at}\nID: ${id}\nResponse: ${body}`,
             }),
           ),
+          ...(response.data.has_more
+            ? [
+                {
+                  type: 'text' as const,
+                  text: 'There are more delivery attempts available. Use the "after" parameter with the last ID to retrieve more.',
+                },
+              ]
+            : []),
         ],
       };
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -83,6 +83,79 @@ const REMOVE_WEBHOOK_TOOL = {
   },
 } as const;
 
+const LIST_WEBHOOK_EVENTS_TOOL = {
+  title: 'List Webhook Events',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List the events Resend delivered to one webhook, most recent first, with the delivery status of each.
+
+**NOT for:** Listing the event types a webhook subscribes to (use get-webhook). Not for listing emails (use list-emails) or the Events product (use list-events).
+
+**Returns:** For each event: id, type (e.g. email.sent), created_at, and status — pending (queued), attempting (a retry is scheduled), success, or failed (retries exhausted).
+
+**When to use:** User asks "did my webhook receive this?", "why is my endpoint missing events?", or wants the delivery history of a webhook. Use get-webhook-event next for the payload, and list-webhook-event-attempts for what their endpoint returned.`,
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Number of events to retrieve. Default: 20, Max: 100, Min: 1'),
+    after: z
+      .string()
+      .nonempty()
+      .optional()
+      .describe(
+        'Event ID to fetch the page after (forward pagination). This endpoint has no "before" cursor.',
+      ),
+  },
+} as const;
+
+const GET_WEBHOOK_EVENT_TOOL = {
+  title: 'Get Webhook Event',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** Get one event delivered to a webhook, including the exact payload Resend sent to the endpoint.
+
+**Returns:** id, type, created_at, status, next_attempt_at (when the next retry is scheduled — null once the event reaches success or failed), and payload (the JSON body sent to the endpoint).
+
+**When to use:** User wants to see what Resend actually sent for a specific event, or when the next retry is due. Get the event ID from list-webhook-events first.`,
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+    eventId: z.string().nonempty().describe('Webhook event ID'),
+  },
+} as const;
+
+const LIST_WEBHOOK_EVENT_ATTEMPTS_TOOL = {
+  title: 'List Webhook Event Attempts',
+  annotations: { readOnlyHint: true },
+  description: `**Purpose:** List the delivery attempts Resend made for one webhook event, most recent first, with what the endpoint returned each time.
+
+**Returns:** For each attempt: id, http_status_code, response (the body the endpoint returned), and sent_at.
+
+**When to use:** An event is in the failed or attempting status and the user wants to know why. This is the tool that shows the endpoint's own error response. Get the event ID from list-webhook-events first.`,
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+    eventId: z.string().nonempty().describe('Webhook event ID'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Number of attempts to retrieve. Default: 20, Max: 100, Min: 1',
+      ),
+    after: z
+      .string()
+      .nonempty()
+      .optional()
+      .describe(
+        'Attempt ID to fetch the page after (forward pagination). This endpoint has no "before" cursor.',
+      ),
+  },
+} as const;
+
 export function addWebhookTools(server: McpServer, resend: Resend) {
   server.registerTool(
     'create-webhook',
@@ -185,6 +258,120 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
         content: [
           { type: 'text', text: 'Webhook updated successfully.' },
           { type: 'text', text: `ID: ${response.data.id}` },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'list-webhook-events',
+    LIST_WEBHOOK_EVENTS_TOOL,
+    async ({ webhookId, limit, after }) => {
+      const response = await resend.webhooks.events.list({
+        webhookId,
+        ...(limit !== undefined && { limit }),
+        ...(after !== undefined && { after }),
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list webhook events: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const events = response.data.data;
+      if (events.length === 0) {
+        return {
+          content: [
+            { type: 'text', text: 'No events delivered to this webhook yet.' },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${events.length} event${events.length === 1 ? '' : 's'}${response.data.has_more ? ' (more available, paginate with "after")' : ''}:`,
+          },
+          ...events.map(({ id, type, status, created_at }) => ({
+            type: 'text' as const,
+            text: `Type: ${type}\nStatus: ${status}\nID: ${id}\nCreated at: ${created_at}`,
+          })),
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'get-webhook-event',
+    GET_WEBHOOK_EVENT_TOOL,
+    async ({ webhookId, eventId }) => {
+      const response = await resend.webhooks.events.get({
+        webhookId,
+        eventId,
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to get webhook event: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const event = response.data;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Type: ${event.type}\nStatus: ${event.status}\nID: ${event.id}\nCreated at: ${event.created_at}\nNext attempt at: ${event.next_attempt_at ?? 'none scheduled'}`,
+          },
+          {
+            type: 'text',
+            text: `Payload:\n${JSON.stringify(event.payload, null, 2)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'list-webhook-event-attempts',
+    LIST_WEBHOOK_EVENT_ATTEMPTS_TOOL,
+    async ({ webhookId, eventId, limit, after }) => {
+      const response = await resend.webhooks.events.attempts.list({
+        webhookId,
+        eventId,
+        ...(limit !== undefined && { limit }),
+        ...(after !== undefined && { after }),
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to list webhook event attempts: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const attempts = response.data.data;
+      if (attempts.length === 0) {
+        return {
+          content: [
+            { type: 'text', text: 'No delivery attempts for this event yet.' },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Found ${attempts.length} attempt${attempts.length === 1 ? '' : 's'}${response.data.has_more ? ' (more available, paginate with "after")' : ''}:`,
+          },
+          ...attempts.map(
+            ({ id, http_status_code, response: body, sent_at }) => ({
+              type: 'text' as const,
+              text: `HTTP status: ${http_status_code}\nSent at: ${sent_at}\nID: ${id}\nResponse: ${body}`,
+            }),
+          ),
         ],
       };
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -90,7 +90,7 @@ const LIST_WEBHOOK_EVENTS_TOOL = {
 
 **NOT for:** Listing the event types a webhook subscribes to (use get-webhook). Not for listing emails (use list-emails) or the Events product (use list-events).
 
-**Returns:** For each event: id, type (e.g. email.sent), created_at, and status — pending (queued), attempting (a retry is scheduled), success, or failed (retries exhausted).
+**Returns:** For each event: id, type (e.g. email.sent), created_at, and status — one of pending, attempting, success, or failed.
 
 **When to use:** User asks "did my webhook receive this?", "why is my endpoint missing events?", or wants the delivery history of a webhook. Use get-webhook-event next for the payload, and list-webhook-event-attempts for what their endpoint returned.`,
   inputSchema: {

--- a/tests/tools/webhooks.test.ts
+++ b/tests/tools/webhooks.test.ts
@@ -93,7 +93,9 @@ describe('webhook event tools', () => {
     });
     const text = textOf(result as never);
     expect(text).toContain('email.sent');
-    expect(text).toContain('more available');
+    expect(text).toContain(
+      'There are more webhook events available. Use the "after" parameter with the last ID to retrieve more.',
+    );
   });
 
   it('get-webhook-event renders next_attempt_at and the payload', async () => {

--- a/tests/tools/webhooks.test.ts
+++ b/tests/tools/webhooks.test.ts
@@ -1,0 +1,198 @@
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
+import type { Resend } from 'resend';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addWebhookTools } from '../../src/tools/webhooks.js';
+
+const listEvents = vi.fn();
+const getEvent = vi.fn();
+const listAttempts = vi.fn();
+
+const resend = {
+  webhooks: {
+    create: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    events: {
+      list: listEvents,
+      get: getEvent,
+      attempts: { list: listAttempts },
+    },
+  },
+} as unknown as Resend;
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+const EVENT_ID = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+async function makeClient() {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  addWebhookTools(server, resend);
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+describe('webhook event tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers the three event tools as read-only', async () => {
+    const client = await makeClient();
+    const { tools } = await client.listTools();
+    const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+
+    expect(byName['list-webhook-events']?.annotations?.readOnlyHint).toBe(true);
+    expect(byName['get-webhook-event']?.annotations?.readOnlyHint).toBe(true);
+    expect(
+      byName['list-webhook-event-attempts']?.annotations?.readOnlyHint,
+    ).toBe(true);
+  });
+
+  it('list-webhook-events sends webhookId and pagination to the SDK', async () => {
+    listEvents.mockResolvedValue({
+      data: {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: EVENT_ID,
+            type: 'email.sent',
+            created_at: '2026-08-22T15:27:42.000Z',
+            status: 'success',
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-webhook-events',
+      arguments: { webhookId: WEBHOOK_ID, limit: 50, after: EVENT_ID },
+    });
+
+    expect(listEvents).toHaveBeenCalledWith({
+      webhookId: WEBHOOK_ID,
+      limit: 50,
+      after: EVENT_ID,
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('email.sent');
+    expect(text).toContain('more available');
+  });
+
+  it('get-webhook-event renders next_attempt_at and the payload', async () => {
+    getEvent.mockResolvedValue({
+      data: {
+        object: 'webhook_event',
+        id: EVENT_ID,
+        type: 'email.sent',
+        created_at: '2026-08-22T15:28:00.000Z',
+        status: 'attempting',
+        next_attempt_at: '2026-08-22T15:33:00.000Z',
+        payload: { type: 'email.sent' },
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'get-webhook-event',
+      arguments: { webhookId: WEBHOOK_ID, eventId: EVENT_ID },
+    });
+
+    expect(getEvent).toHaveBeenCalledWith({
+      webhookId: WEBHOOK_ID,
+      eventId: EVENT_ID,
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('2026-08-22T15:33:00.000Z');
+    expect(text).toContain('"type": "email.sent"');
+  });
+
+  it('get-webhook-event says so when no retry is scheduled', async () => {
+    getEvent.mockResolvedValue({
+      data: {
+        object: 'webhook_event',
+        id: EVENT_ID,
+        type: 'email.sent',
+        created_at: '2026-08-22T15:28:00.000Z',
+        status: 'success',
+        next_attempt_at: null,
+        payload: {},
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'get-webhook-event',
+      arguments: { webhookId: WEBHOOK_ID, eventId: EVENT_ID },
+    });
+
+    expect(textOf(result as never)).toContain('none scheduled');
+  });
+
+  it('list-webhook-event-attempts surfaces what the endpoint returned', async () => {
+    listAttempts.mockResolvedValue({
+      data: {
+        object: 'list',
+        has_more: false,
+        data: [
+          {
+            id: 'atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd',
+            http_status_code: 500,
+            response: 'Internal Server Error',
+            sent_at: '2026-08-22T15:28:05.000Z',
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-webhook-event-attempts',
+      arguments: { webhookId: WEBHOOK_ID, eventId: EVENT_ID },
+    });
+
+    expect(listAttempts).toHaveBeenCalledWith({
+      webhookId: WEBHOOK_ID,
+      eventId: EVENT_ID,
+    });
+    const text = textOf(result as never);
+    expect(text).toContain('500');
+    expect(text).toContain('Internal Server Error');
+  });
+
+  it('surfaces the API error when a list fails', async () => {
+    listEvents.mockResolvedValue({
+      data: null,
+      error: { message: 'Webhook endpoint not found', name: 'not_found' },
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'list-webhook-events',
+      arguments: { webhookId: WEBHOOK_ID },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Webhook endpoint not found');
+  });
+});


### PR DESCRIPTION
Adds three read-only tools for the webhook event endpoints that went GA.

Linear: https://linear.app/resend/issue/DEV-1932

| Tool | Endpoint |
| --- | --- |
| `list-webhook-events` | `GET /webhooks/{webhook_id}/events` |
| `get-webhook-event` | `GET /webhooks/{webhook_id}/events/{event_id}` |
| `list-webhook-event-attempts` | `GET /webhooks/{webhook_id}/events/{event_id}/attempts` |

The same three land in the remote server in the monorepo, with the same names, schemas and output text.

## Notes

- The descriptions steer the model down the debugging path: list to find the event, get for the payload we sent, attempts for what the endpoint returned. `list-webhook-events` carries a **NOT for** section, because `list-events` (the Events product) and `get-webhook` (which returns the *subscribed* event types) are easy to confuse with it.
- These endpoints paginate forward only, so the schemas expose `limit` and `after` and no `before`. A well-formed `?before=` returns 422 "The `before` parameter is not supported for this endpoint."
- `get-webhook-event` renders `next_attempt_at` as `none scheduled` when null.
- Bumps `resend` 6.23.0 to 6.25.0 — `webhooks.events` became stable in 6.24.0 — and the package to 2.18.0 so a release can be cut off the merge.

## Checks

`pnpm build` and `pnpm lint` clean (the 3 biome warnings are pre-existing, in `cli/resolve.ts` and `transports/http.ts`). Tests: 20 files, 223 passed.

Smoke-ran all three through an in-memory MCP client against production.

**The data path is unverified.** Every live call returned an empty page or a 404 — this account records no webhook events. I sent one email to try to generate one; it reached `delivered`, but no event appeared on any enabled webhook after three minutes. So rendering a populated response is covered by unit tests only, and the descriptions state the status enum without claiming what each value means.

Also adds `suppression.added` and `suppression.removed` to the webhook event enum. The SDK's `WebhookEvent` type has carried both since 6.23.0 and the API accepts them; the CLI already offers all 19, so `create-webhook` and `update-webhook` were two events short.