### PR TITLE
feat(webhooks): add replay-webhook-event tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Topics**: Create, list, get, update, and remove subscription topics.
 - **Contact Properties**: Create, list, get, update, and remove custom contact attributes.
 - **API Keys**: Create, list, update, and remove API keys.
-- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications, and inspect their delivery history — the events sent to a webhook, one event's payload, and the attempts made to deliver it.
+- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications, and inspect their delivery history — the events sent to a webhook, one event's payload, and the attempts made to deliver it. Replay an event to queue another delivery.
 - **Logs**: List and inspect API request logs, including full request and response bodies.
 - **Editor**: Connect to (and disconnect from) the visual editor in the Resend dashboard, and read a draft's content while collaborating on broadcasts and templates.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.25.0",
+    "resend": "6.26.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.25.0
-        version: 6.25.0
+        specifier: 6.26.0
+        version: 6.26.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.25.0:
-    resolution: {integrity: sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==}
+  resend@6.26.0:
+    resolution: {integrity: sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.25.0:
+  resend@6.26.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -128,6 +128,19 @@ const GET_WEBHOOK_EVENT_TOOL = {
   },
 } as const;
 
+const REPLAY_WEBHOOK_EVENT_TOOL = {
+  title: 'Replay Webhook Event',
+  description: `**Purpose:** Queue one more delivery of a webhook event to its endpoint — the same action as the dashboard's Replay button.
+
+**NOT for:** Inspecting an event (use get-webhook-event) or its past attempts (use list-webhook-event-attempts). A manual replay does not schedule further automatic retries.
+
+**When to use:** User wants to resend a specific webhook event after fixing their endpoint, or re-trigger a delivery that failed or was missed. Get the event ID from list-webhook-events first.`,
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
+    eventId: z.string().nonempty().describe('Webhook event ID'),
+  },
+} as const;
+
 const LIST_WEBHOOK_EVENT_ATTEMPTS_TOOL = {
   title: 'List Webhook Event Attempts',
   annotations: { readOnlyHint: true },
@@ -337,6 +350,30 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
             type: 'text',
             text: `Payload:\n${JSON.stringify(event.payload, null, 2)}`,
           },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'replay-webhook-event',
+    REPLAY_WEBHOOK_EVENT_TOOL,
+    async ({ webhookId, eventId }) => {
+      const response = await resend.webhooks.events.replay({
+        webhookId,
+        eventId,
+      });
+
+      if (response.error) {
+        throw new Error(
+          `Failed to replay webhook event: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: 'text', text: 'Webhook event replay queued.' },
+          { type: 'text', text: `ID: ${response.data.id}` },
         ],
       };
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -134,7 +134,7 @@ const REPLAY_WEBHOOK_EVENT_TOOL = {
 
 **NOT for:** Inspecting an event (use get-webhook-event) or its past attempts (use list-webhook-event-attempts). A manual replay does not schedule further automatic retries.
 
-**When to use:** User wants to resend a specific webhook event after fixing their endpoint, or re-trigger a delivery that failed or was missed. Get the event ID from list-webhook-events first.`,
+**When to use:** User wants to resend a specific webhook event after fixing their endpoint, or re-trigger a delivery that failed or was missed. The webhook must be enabled — a disabled webhook fails this call. Get the event ID from list-webhook-events first.`,
   inputSchema: {
     webhookId: z.string().nonempty().describe('Webhook ID'),
     eventId: z.string().nonempty().describe('Webhook event ID'),

--- a/tests/tools/webhooks.test.ts
+++ b/tests/tools/webhooks.test.ts
@@ -6,6 +6,7 @@ import { addWebhookTools } from '../../src/tools/webhooks.js';
 
 const listEvents = vi.fn();
 const getEvent = vi.fn();
+const replayEvent = vi.fn();
 const listAttempts = vi.fn();
 
 const resend = {
@@ -18,6 +19,7 @@ const resend = {
     events: {
       list: listEvents,
       get: getEvent,
+      replay: replayEvent,
       attempts: { list: listAttempts },
     },
   },
@@ -148,6 +150,25 @@ describe('webhook event tools', () => {
     });
 
     expect(textOf(result as never)).toContain('none scheduled');
+  });
+
+  it('replay-webhook-event sends webhookId and eventId to the SDK', async () => {
+    replayEvent.mockResolvedValue({
+      data: { object: 'webhook_event', id: EVENT_ID },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'replay-webhook-event',
+      arguments: { webhookId: WEBHOOK_ID, eventId: EVENT_ID },
+    });
+
+    expect(replayEvent).toHaveBeenCalledWith({
+      webhookId: WEBHOOK_ID,
+      eventId: EVENT_ID,
+    });
+    expect(textOf(result as never)).toContain(EVENT_ID);
   });
 
   it('list-webhook-event-attempts surfaces what the endpoint returned', async () => {


### PR DESCRIPTION
Adds a tool for the new webhook event replay endpoint.

| Tool | Endpoint |
| --- | --- |
| `replay-webhook-event` | `POST /webhooks/{webhook_id}/events/{event_id}/replay` |

The same tool lands in the remote server in the monorepo, with the same name, schema, and output text — another agent is opening that PR in parallel, so both servers stay in sync.

## Blocked on the resend-node 6.26.0 npm publish

This bumps `resend` to `6.26.0` for `webhooks.events.replay()`, added in resend/resend-node#1087 (merged upstream, not yet published to npm). `pnpm install --frozen-lockfile` will fail on this PR as committed until that version reaches the registry: resend/resend-node#1087.

Verified locally instead by building against that branch: `pnpm add resend@file:<local resend-node checkout>` (dist built there, `package.json` at `6.26.0`), then ran tests/build/lint against the real package. Before committing, `package.json` and `pnpm-lock.yaml` were restored to a plain `6.26.0` semver pin (no `file:` reference) so the diff reads like a normal version bump — its `resend@6.26.0` lockfile entry carries the old `6.25.0` integrity hash as a placeholder and needs `pnpm install` to regenerate it for real once the package is published.

## Notes

- Mirrors `get-webhook-event`'s shape: same two params (`webhookId`, `eventId`), same error format.
- Unlike the read-only event tools from #221, this is a write action, so it carries no `annotations` object — same convention as `create-webhook`/`update-webhook`/`remove-webhook`.
- The description calls out that a manual replay does not schedule further automatic retries, so the model doesn't imply otherwise.
- Also bumps the package version to `2.19.0`, matching how #221 bumped both `resend` and the package version in the same PR when it needed a fresh SDK method.

## Checks

- `pnpm test`: 20 files, 224 passed (run against the local resend-node build described above).
- `pnpm build`: clean (run against the local build).
- `pnpm lint`: clean — same 3 pre-existing biome warnings in `cli/resolve.ts` and `transports/http.ts` as #221, unrelated to this change.
- `node ./scripts/check-dependency-versions.ts`: passes against the final committed `package.json`.
- `pnpm install --frozen-lockfile` against the final committed lockfile: fails with a 404 fetching `resend@6.26.0` from the registry, as expected — this is the blocker above, not a lockfile bug.
- No live API calls (replay is a write endpoint and there is no key configured).

Spec PR: resend/resend-openapi#112
Public API PR: resend/resend-monorepo#9535
SDK method: resend/resend-node#1087

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2018
