### PR TITLE
fix: pass empty subject through update-template

### DIFF
--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -273,7 +273,7 @@ export function addTemplateTools(
       const response = await resend.templates.create({
         name,
         html,
-        ...(subject && { subject }),
+        ...(subject !== undefined && { subject }),
         ...(from && { from }),
         ...(replyTo && { replyTo }),
         ...(text !== undefined && { text }),
@@ -544,7 +544,7 @@ export function addTemplateTools(
       const response = await resend.templates.update(id, {
         ...(name && { name }),
         ...(html && { html }),
-        ...(subject && { subject }),
+        ...(subject !== undefined && { subject }),
         ...(from && { from }),
         ...(replyTo && { replyTo }),
         ...(text !== undefined && { text }),

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -72,4 +72,18 @@ describe('template text content', () => {
     expect(result.isError).toBeFalsy();
     expect(update).toHaveBeenCalledWith('tmpl_1', { text: '' });
   });
+
+  it('passes empty subject through update-template', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'update-template',
+      arguments: {
+        id: 'tmpl_1',
+        subject: '',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(update).toHaveBeenCalledWith('tmpl_1', { subject: '' });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #208 — calling `update-template` with an explicit empty-string `subject` reported success but silently dropped the value because `subject && { subject }` evaluates to falsy for ``.

Changed to `subject !== undefined && { subject }`, matching the pattern already used for the `text` field.

Also fixed the same issue in `create-template` for consistency.

## Changes

- `src/tools/templates.ts`: Two occurrences of `...(subject && { subject })` changed to `...(subject !== undefined && { subject })`
- `tests/tools/templates.test.ts`: Added regression test verifying empty string `subject` is passed through in `update-template`

## Testing

```
✓ tests/tools/templates.test.ts (3 tests)
```

Fixes #208.