### PR TITLE
feat(webhooks): add rotate-webhook-signing-secret tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Topics**: Create, list, get, update, and remove subscription topics.
 - **Contact Properties**: Create, list, get, update, and remove custom contact attributes.
 - **API Keys**: Create, list, update, and remove API keys.
-- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications, and inspect their delivery history — the events sent to a webhook, one event's payload, and the attempts made to deliver it. Replay an event to queue another delivery.
+- **Webhooks**: Create, list, get, update, and remove webhooks for event notifications, and inspect their delivery history — the events sent to a webhook, one event's payload, and the attempts made to deliver it. Replay an event to queue another delivery, and rotate a webhook's signing secret.
 - **Logs**: List and inspect API request logs, including full request and response bodies.
 - **Editor**: Connect to (and disconnect from) the visual editor in the Resend dashboard, and read a draft's content while collaborating on broadcasts and templates.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.26.0",
+    "resend": "6.27.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.2.8
         version: 1.2.8
       resend:
-        specifier: 6.26.0
-        version: 6.26.0
+        specifier: 6.27.0
+        version: 6.27.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  resend@6.26.0:
-    resolution: {integrity: sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==}
+  resend@6.27.0:
+    resolution: {integrity: sha512-5Auh9GWkmKteeEM7rG45j7JRQVsKaQG0Okk4Ev0Pekh+1qfclRsmd4alZ3Kx0AqEosnZjEe/kCXf9jxfGaPZtg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1622,7 +1622,7 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
-  resend@6.26.0:
+  resend@6.27.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import type { Resend } from 'resend';
+import type { CreateWebhookResponse, Resend } from 'resend';
 import { z } from 'zod';
 
 const webhookEventSchema = z.enum([
@@ -138,6 +138,18 @@ const REPLAY_WEBHOOK_EVENT_TOOL = {
   inputSchema: {
     webhookId: z.string().nonempty().describe('Webhook ID'),
     eventId: z.string().nonempty().describe('Webhook event ID'),
+  },
+} as const;
+
+const ROTATE_WEBHOOK_SIGNING_SECRET_TOOL = {
+  title: 'Rotate Webhook Signing Secret',
+  description: `**Purpose:** Replace a webhook's signing secret with a new one — the same action as the dashboard's Rotate button. Returns the new secret.
+
+**NOT for:** Changing the endpoint URL or subscribed events (use update-webhook), or reading the current secret (use get-webhook).
+
+**When to use:** User believes the signing secret leaked, or wants to rotate it as routine hygiene. Payloads delivered after the rotation are signed with the new secret, so the user must update their endpoint's verification code with it.`,
+  inputSchema: {
+    webhookId: z.string().nonempty().describe('Webhook ID'),
   },
 } as const;
 
@@ -374,6 +386,39 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
         content: [
           { type: 'text', text: 'Webhook event replay queued.' },
           { type: 'text', text: `ID: ${response.data.id}` },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'rotate-webhook-signing-secret',
+    ROTATE_WEBHOOK_SIGNING_SECRET_TOOL,
+    async ({ webhookId }) => {
+      const response = await (
+        resend.webhooks as unknown as {
+          rotateSigningSecret: (id: string) => Promise<CreateWebhookResponse>;
+        }
+      ).rotateSigningSecret(webhookId);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to rotate webhook signing secret: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      const rotated = response.data;
+      return {
+        content: [
+          { type: 'text', text: 'Webhook signing secret rotated.' },
+          {
+            type: 'text',
+            text: `ID: ${rotated.id}\nSigning Secret: ${rotated.signing_secret}`,
+          },
+          {
+            type: 'text',
+            text: 'IMPORTANT: Make sure to tell the user the new signing secret — their endpoint must verify payloads with it from now on.',
+          },
         ],
       };
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -147,7 +147,7 @@ const ROTATE_WEBHOOK_SIGNING_SECRET_TOOL = {
 
 **NOT for:** Changing the endpoint URL or subscribed events (use update-webhook), or reading the current secret (use get-webhook).
 
-**When to use:** User believes the signing secret leaked, or wants to rotate it as routine hygiene. Payloads delivered after the rotation are signed with the new secret, so the user must update their endpoint's verification code with it.`,
+**When to use:** User believes the signing secret leaked, or wants to rotate it as routine hygiene. Payloads delivered after the rotation are signed with the new secret. The previous secret keeps working for 24 hours, so the user has that window to update their endpoint's verification code.`,
   inputSchema: {
     webhookId: z.string().nonempty().describe('Webhook ID'),
   },
@@ -417,7 +417,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
           },
           {
             type: 'text',
-            text: 'IMPORTANT: Make sure to tell the user the new signing secret — their endpoint must verify payloads with it from now on.',
+            text: 'IMPORTANT: Make sure to tell the user the new signing secret. The previous secret keeps working for 24 hours; after that only the new one verifies payloads.',
           },
         ],
       };

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -147,7 +147,7 @@ const ROTATE_WEBHOOK_SIGNING_SECRET_TOOL = {
 
 **NOT for:** Changing the endpoint URL or subscribed events (use update-webhook), or reading the current secret (use get-webhook).
 
-**When to use:** User believes the signing secret leaked, or wants to rotate it as routine hygiene. Payloads delivered after the rotation are signed with the new secret. The previous secret keeps working for 24 hours, so the user has that window to update their endpoint's verification code.`,
+**When to use:** User believes the signing secret leaked, or wants to rotate it as routine hygiene. For 24 hours, payloads are signed with both the new and the previous secret, so either one verifies them. After that, only the new secret does. The user has that window to update their endpoint's verification code.`,
   inputSchema: {
     webhookId: z.string().nonempty().describe('Webhook ID'),
   },
@@ -417,7 +417,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
           },
           {
             type: 'text',
-            text: 'IMPORTANT: Make sure to tell the user the new signing secret. The previous secret keeps working for 24 hours; after that only the new one verifies payloads.',
+            text: 'IMPORTANT: Make sure to tell the user the new signing secret. For 24 hours payloads are signed with both the new and the previous secret; after that only the new one verifies them.',
           },
         ],
       };

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import type { CreateWebhookResponse, Resend } from 'resend';
+import type { Resend } from 'resend';
 import { z } from 'zod';
 
 const webhookEventSchema = z.enum([
@@ -395,11 +395,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
     'rotate-webhook-signing-secret',
     ROTATE_WEBHOOK_SIGNING_SECRET_TOOL,
     async ({ webhookId }) => {
-      const response = await (
-        resend.webhooks as unknown as {
-          rotateSigningSecret: (id: string) => Promise<CreateWebhookResponse>;
-        }
-      ).rotateSigningSecret(webhookId);
+      const response = await resend.webhooks.rotateSigningSecret(webhookId);
 
       if (response.error) {
         throw new Error(

--- a/tests/tools/webhooks.test.ts
+++ b/tests/tools/webhooks.test.ts
@@ -7,6 +7,7 @@ import { addWebhookTools } from '../../src/tools/webhooks.js';
 const listEvents = vi.fn();
 const getEvent = vi.fn();
 const replayEvent = vi.fn();
+const rotateSigningSecret = vi.fn();
 const listAttempts = vi.fn();
 
 const resend = {
@@ -16,6 +17,7 @@ const resend = {
     get: vi.fn(),
     update: vi.fn(),
     remove: vi.fn(),
+    rotateSigningSecret,
     events: {
       list: listEvents,
       get: getEvent,
@@ -169,6 +171,26 @@ describe('webhook event tools', () => {
       eventId: EVENT_ID,
     });
     expect(textOf(result as never)).toContain(EVENT_ID);
+  });
+
+  it('rotate-webhook-signing-secret returns the new secret', async () => {
+    rotateSigningSecret.mockResolvedValue({
+      data: {
+        object: 'webhook',
+        id: WEBHOOK_ID,
+        signing_secret: 'whsec_rotated',
+      },
+      error: null,
+    });
+
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'rotate-webhook-signing-secret',
+      arguments: { webhookId: WEBHOOK_ID },
+    });
+
+    expect(rotateSigningSecret).toHaveBeenCalledWith(WEBHOOK_ID);
+    expect(textOf(result as never)).toContain('whsec_rotated');
   });
 
   it('list-webhook-event-attempts surfaces what the endpoint returned', async () => {


### PR DESCRIPTION
Adds the `rotate-webhook-signing-secret` tool for the new `POST /webhooks/{webhook_id}/signing-secret/rotate` endpoint (spec: https://github.com/resend/resend-openapi/pull/113, tracking: https://linear.app/resend/issue/DEV-2081). It takes a webhook ID, calls `resend.webhooks.rotateSigningSecret(id)`, and prints the new secret the same way create-webhook does. The `resend` pin moves to 6.27.0, the release that ships the method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)