### PR TITLE
chore: bump version to 2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "license": "MIT",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release bump for the `rotate-webhook-signing-secret` tool from #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)