### PR TITLE
fix(webhooks): point create-webhook at get-webhook for the signing secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -48,7 +48,8 @@ const LIST_WEBHOOKS_TOOL = {
 const GET_WEBHOOK_TOOL = {
   title: 'Get Webhook',
   annotations: { readOnlyHint: true },
-  description: 'Get a webhook by ID from Resend.',
+  description:
+    'Get a webhook by ID from Resend, including its signing secret. Use this when the user needs the current secret to verify payloads; use rotate-webhook-signing-secret only to replace it.',
   inputSchema: {
     webhookId: z.string().nonempty().describe('Webhook ID'),
   },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -206,7 +206,7 @@ export function addWebhookTools(server: McpServer, resend: Resend) {
           },
           {
             type: 'text',
-            text: 'IMPORTANT: Make sure to tell the user the signing secret — they will need it to verify webhook payloads and it cannot be retrieved again later.',
+            text: 'IMPORTANT: Make sure to tell the user the signing secret — they will need it to verify webhook payloads. get-webhook returns it again if needed.',
           },
         ],
       };


### PR DESCRIPTION
`GET /webhooks/{id}` returns `signing_secret`, and get-webhook already prints it. The create-webhook message told the agent the secret could not be retrieved again; it now points at get-webhook. The get-webhook description says it returns the secret, so an agent asked for the current secret reads it instead of rotating. Same fix in the remote MCP twin, https://github.com/resend/resend-monorepo/pull/10229. Version moves to 2.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)