### PR TITLE
feat(broadcasts): add duplicate-broadcast tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Resend's MCP server gives your AI agent native access to the full Resend platfor
 - **Received Emails**: List and read inbound emails. List and download received email attachments.
 - **Templates**: Create, list, get, update, publish, duplicate, and remove email templates. Supports composing template content and `{{{VARIABLE}}}` placeholders.
 - **Contacts**: Create, list, get, update, and remove contacts. Manage segment memberships, topic subscriptions, and CSV contact imports. Supports custom contact properties.
-- **Broadcasts**: Create, send, cancel, list, get, update, and remove broadcast campaigns. List a broadcast's clicked links, and its recipients by event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed). Supports scheduling, personalization placeholders, and preview text.
+- **Broadcasts**: Create, send, cancel, duplicate, list, get, update, and remove broadcast campaigns. List a broadcast's clicked links, and its recipients by event type (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed). Supports scheduling, personalization placeholders, and preview text.
 - **Automations**: Create, list, get, update, duplicate, and remove automations. Review the runs of an automation.
 - **Events**: Send events to trigger automations for a contact. Create, update, and remove event definitions.
 - **Domains**: Create, list, get, update, remove, and verify sender domains. Configure tracking, TLS, and sending/receiving capabilities. Create and verify domain claims.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-mcp",
-  "version": "2.20.1",
+  "version": "2.21.0",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "17.4.2",
     "express": "5.2.1",
     "minimist": "1.2.8",
-    "resend": "6.27.0",
+    "resend": "6.28.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/src/tools/broadcasts.ts
+++ b/src/tools/broadcasts.ts
@@ -169,6 +169,23 @@ const CANCEL_BROADCAST_TOOL = {
   },
 } as const;
 
+const DUPLICATE_BROADCAST_TOOL = {
+  title: 'Duplicate Broadcast',
+  description: `**Purpose:** Duplicate a broadcast by ID or Resend dashboard URL. Creates a new draft broadcast with the same segment, topic, sender, subject, reply-to, preview text, and content as the source, named after the source with " (copy)" appended (truncated to 70 characters). Any broadcast can be duplicated, including sent ones.
+
+**NOT for:** Editing the source broadcast (use update-broadcast) or sending the copy (use send-broadcast on the new draft's ID).
+
+**When to use:** User wants to "copy", "clone", "duplicate", or "reuse" an existing broadcast as the starting point for a new one.`,
+  inputSchema: {
+    broadcastId: z
+      .string()
+      .nonempty()
+      .describe(
+        'Broadcast ID or Resend dashboard URL (e.g. https://resend.com/broadcasts/<id>)',
+      ),
+  },
+} as const;
+
 const REMOVE_BROADCAST_TOOL = {
   title: 'Remove Broadcast',
   description:
@@ -647,6 +664,28 @@ export function addBroadcastTools(
         content: [
           { type: 'text', text: 'Broadcast cancelled successfully.' },
           { type: 'text', text: `ID: ${response.data.id}` },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'duplicate-broadcast',
+    DUPLICATE_BROADCAST_TOOL,
+    async ({ broadcastId: rawBroadcastId }) => {
+      const broadcastId = extractIdFromUrl(rawBroadcastId, 'broadcasts');
+      const response = await resend.broadcasts.duplicate(broadcastId);
+
+      if (response.error) {
+        throw new Error(
+          `Failed to duplicate broadcast: ${JSON.stringify(response.error)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: 'text', text: 'Broadcast duplicated successfully (draft).' },
+          { type: 'text', text: `New broadcast ID: ${response.data.id}` },
         ],
       };
     },

--- a/tests/tools/broadcasts.test.ts
+++ b/tests/tools/broadcasts.test.ts
@@ -7,9 +7,10 @@ import { addBroadcastTools } from '../../src/tools/broadcasts.js';
 
 const clickedLinks = vi.fn();
 const recipients = vi.fn();
+const duplicate = vi.fn();
 
 const resend = {
-  broadcasts: { clickedLinks, recipients },
+  broadcasts: { clickedLinks, recipients, duplicate },
 } as unknown as Resend;
 
 const apiClient = {} as ResendEditorClient;
@@ -517,5 +518,52 @@ describe('list-broadcast-recipients', () => {
     expect(textOf(result as never)).toContain(
       'Failed to list broadcast recipients',
     );
+  });
+});
+
+describe('duplicate-broadcast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    duplicate.mockResolvedValue({
+      data: { object: 'broadcast', id: 'bc_copy' },
+      error: null,
+    });
+  });
+
+  it('duplicates a broadcast and returns the new draft id', async () => {
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'duplicate-broadcast',
+      arguments: { broadcastId: 'bc_1' },
+    });
+
+    expect(duplicate).toHaveBeenCalledWith('bc_1');
+    expect(textOf(result as never)).toContain('Broadcast duplicated');
+    expect(textOf(result as never)).toContain('New broadcast ID: bc_copy');
+  });
+
+  it('extracts the id from a dashboard URL', async () => {
+    const client = await makeClient();
+    await client.callTool({
+      name: 'duplicate-broadcast',
+      arguments: { broadcastId: 'https://resend.com/broadcasts/bc_1' },
+    });
+
+    expect(duplicate).toHaveBeenCalledWith('bc_1');
+  });
+
+  it('surfaces SDK errors', async () => {
+    duplicate.mockResolvedValueOnce({
+      data: null,
+      error: { name: 'not_found', message: 'Broadcast not found' },
+    });
+    const client = await makeClient();
+    const result = await client.callTool({
+      name: 'duplicate-broadcast',
+      arguments: { broadcastId: 'bc_404' },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as never)).toContain('Failed to duplicate broadcast');
+    expect(textOf(result as never)).toContain('Broadcast not found');
   });
 });


### PR DESCRIPTION
Blocked on resend@6.28.0 reaching npm. Until then `pnpm install --frozen-lockfile` fails in CI: package.json pins 6.28.0 (the first release with `resend.broadcasts.duplicate`, https://github.com/resend/resend-node/pull/1094) and pnpm-lock.yaml stays as on main so the lockfile follows the release in a second commit. Lint, tests, build, and the pin check pass locally against a pack of that branch.

Adds `duplicate-broadcast`, wrapping `resend.broadcasts.duplicate` (POST `/broadcasts/{id}/duplicate`, the endpoint from https://github.com/resend/resend-monorepo/pull/9608) so an agent can clone any broadcast, sent ones included, into a new draft and get the new ID back. The monorepo remote MCP gets the same tool (same name, description, and input schema) in https://github.com/resend/resend-monorepo/pull/10273. Releases as 2.21.0.

Claude ran the harness below from the repo root against `dist` and staging, then deleted the copy.

```
$ RESEND_API_KEY=$(fish -c ds) RESEND_BASE_URL=https://api.resend-staging.com node qa-duplicate-broadcast.mjs
{"isError":false}
Broadcast duplicated successfully (draft).
New broadcast ID: 4d10056a-bc66-45a2-9894-cdbe29a15035
$ http DELETE https://api.resend-staging.com/broadcasts/4d10056a-bc66-45a2-9894-cdbe29a15035 "Authorization: Bearer $(fish -c ds)"
{"object":"broadcast","id":"4d10056a-bc66-45a2-9894-cdbe29a15035","deleted":true}
```

<details>
<summary>qa-duplicate-broadcast.mjs</summary>

```js
import { Client } from '@modelcontextprotocol/client';
import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
import { Resend } from 'resend';
import { addBroadcastTools } from './dist/tools/broadcasts.js';

const resend = new Resend(process.env.RESEND_API_KEY);
const server = new McpServer({ name: 'qa', version: '0.0.0' });
addBroadcastTools(server, resend, {}, {
  replierEmailAddresses: [],
  withEditorSession: async (_conn, fn) => fn(),
});
const client = new Client({ name: 'qa-client', version: '0.0.0' });
const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
await Promise.all([
  server.connect(serverTransport),
  client.connect(clientTransport),
]);

const result = await client.callTool({
  name: 'duplicate-broadcast',
  arguments: { broadcastId: 'e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16' },
});
console.log(JSON.stringify({ isError: result.isError ?? false }));
for (const block of result.content) {
  if (block.type === 'text') console.log(block.text);
}
await client.close();
```

</details>

Still open after three adversarial-review rounds: the reviewer would drop the `duplicate-broadcast` tests (kept, they follow the sibling tests in this file) and shorten the tool description (kept verbatim so it stays identical to the remote-mcp twin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

